### PR TITLE
feat: add TOML-based configuration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,11 +352,32 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -367,8 +388,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.61.1",
+ "redox_users 0.5.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -396,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -879,18 +900,21 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
 name = "org-core"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "nucleo-matcher",
  "orgize",
  "serde",
  "serde_json",
  "shellexpand",
  "tempfile",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -1043,6 +1067,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -1180,7 +1215,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1285,6 +1320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,7 +1343,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -1369,7 +1413,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1529,6 +1573,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower-service"
@@ -1779,7 +1864,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1923,6 +2008,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1949,12 +2043,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.61.1"
+name = "windows-targets"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows-link 0.2.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2001,6 +2101,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2013,6 +2119,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2022,6 +2134,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2049,6 +2167,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2058,6 +2182,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2073,6 +2203,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2085,6 +2221,12 @@ checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2094,6 +2236,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,17 @@ members = ["mcp-server", "org-cli", "org-core"]
 nucleo-matcher = "0.3"
 orgize = { version = "0.10.0-alpha.10", features = ["tracing"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.143"
+serde_json = "1.0.145"
 shellexpand = "3.1.1"
 tracing = "0.1.41"
-walkdir = "2.4"
+walkdir = "2.5"
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 assert_cmd = "2.0"
+dirs = "5"
+toml = "0.8"
 predicates = "3.1"
-tempfile = "3.12"
+tempfile = "3.23"
 org-core = { version = "0.1.0", path = "../org-core" }
 rmcp = { version = "0.8.0", features = [
   "transport-io",

--- a/README.org
+++ b/README.org
@@ -20,8 +20,8 @@ linking capabilities for your org-mode files through the MCP protocol.
 ** MCP Resources
 
 - =org://= — List all org-mode files in configured directories
-- =org://{file}= — Access raw content of org files
-- =org-outline://{file}= — Get hierarchical structure as JSON
+- =org://{file}= — Access raw content of ={file}=
+- =org-outline://{file}= — Get hierarchical structure of ={file}= as JSON
 - =org-heading://{file}#{heading}= — Access specific headings by path
 - =org-id://{id}= — Find content by org-mode ID properties
 
@@ -32,7 +32,10 @@ linking capabilities for your org-mode files through the MCP protocol.
 
 ** CLI Tool
 
-- =org-cli list= — List all .org files in a directory
+- =org-cli config init= — Create default configuration file
+- =org-cli config show= — Display current configuration
+- =org-cli config path= — Show configuration file location
+- =org-cli list= — List all .org files in configured directory
 - =org-cli init= — Initialize or validate an org directory
 - =org-cli read= — Read the contents of an org file
 - =org-cli outline= — Get the outline (headings) of an org file
@@ -40,36 +43,86 @@ linking capabilities for your org-mode files through the MCP protocol.
 - =org-cli element-by-id= — Extract content from an element by ID across all org files
 - =org-cli search= — Search for text content across all org files using fuzzy matching
 
-* Usage Examples
+* Configuration
 
-** Search Commands
+The project uses a TOML configuration file located at
+  =~/.config/org-mcp-server.toml= (or =$XDG_CONFIG_HOME/org-mcp-server.toml=).
 
-#+begin_src bash
-# Basic search
-org-cli search "project planning"
+** Configuration Hierarchy
 
-# Limit results and use JSON output
-org-cli search "TODO" --limit 5 --format json
+Configuration is resolved in the following order (highest priority first):
 
-# Search in specific directory with custom snippet size
-org-cli search "meeting notes" --dir ~/documents/org --snippet-size 50
+1. *CLI flags* — Command-line arguments override everything
+2. *Environment variables* — =ORG_*= prefixed variables
+3. *Configuration file* — TOML file in config directory
+4. *Default values* — Built-in fallbacks
 
-# Full parameter example
-org-cli search "bug fix" -d ~/projects/notes -l 10 -s 75 -f json
+** Configuration File Format
+
+#+begin_src toml
+[org]
+# Root directory containing org-mode files
+root_directory = "~/org/"
+# Default notes file for new notes
+default_notes_file = "notes.org"
+# Agenda files to include
+agenda_files = ["agenda.org", "projects.org"]
+# Extra files for text search beyond regular org files
+agenda_text_search_extra_files = ["archive.org"]
+
+[logging]
+# Log level: trace, debug, info, warn, error
+level = "info"
+# Log file location (MCP server only, CLI logs to stderr)
+file = "~/.local/share/org-mcp-server/logs/server.log"
+
+[cli]
+# Default output format for CLI commands
+default_format = "plain"  # plain | json
 #+end_src
 
-** Search Parameters
+** Environment Variables
 
-- =--dir/-d= — Directory to search for org files (default: =~/org/=)
-- =--limit/-l= — Maximum number of results to return
-- =--format/-f= — Output format: =plain= or =json= (default: =plain=)
-- =--snippet-size/-s= — Maximum snippet size in characters (default: =100=)
+- =ORG_ROOT_DIRECTORY= — Root directory for org files
+- =ORG_DEFAULT_NOTES_FILE= — Default notes file name
+- =ORG_AGENDA_FILES= — Comma-separated list of agenda files
+- =ORG_AGENDA_TEXT_SEARCH_EXTRA_FILES= — Comma-separated extra search files
+- =ORG_LOG_LEVEL= — Log level for server
+- =ORG_LOG_FILE= — Log file location for server
 
-The search uses fuzzy matching with:
-- AND logic for multiple terms (all terms must match on the same line)
-- Unicode-safe text processing
-- Ranked results by relevance score
-- Configurable snippet truncation with "…" indicator
+** Configuration Commands
+
+#+begin_src bash
+# Create default configuration file
+org config init
+
+# Show current resolved configuration
+org config show
+
+# Show configuration file path
+org config path
+#+end_src
+
+* Usage Examples
+
+** Basic Commands
+
+#+begin_src bash
+# List all org files using configuration
+org list
+
+# List with JSON output
+org list --format json
+
+# Search across all configured org files
+org search "project planning"
+
+# Search with custom parameters
+org search "TODO" --limit 5 --format json --snippet-size 75
+
+# Override root directory for a single command
+org --root-directory ~/documents/org search "meeting notes"
+#+end_src
 
 * Architecture
 
@@ -86,7 +139,7 @@ Built with:
 - [[https://crates.io/crates/tokio][tokio]] for async runtime
 - [[https://crates.io/crates/nucleo-matcher][nucleo-matcher]] for fuzzy text search
 
-* Installation
+* Setup
 
 ** Using Nix Flakes
 
@@ -116,9 +169,9 @@ cargo run --bin org-mcp-server
 cargo run --bin org-cli -- list
 #+end_src
 
-* Configuration
+* MCP Server Integration
 
-** AI Agent integration
+** AI Agent Configuration
 
 Add the following to your agent configuration (e.g.,
    =~/.config/opencode/opencode.json=, =~/.claude.json=, etc.):
@@ -128,7 +181,7 @@ Add the following to your agent configuration (e.g.,
   "mcpServers": {
     "org-mode": {
       "command": "/path/to/org-mcp-server",
-      "args": ["--root", "/path/to/your/org/files"],
+      "args": [],
       "env": {}
     }
   }
@@ -142,18 +195,31 @@ Or if installed via Nix:
   "mcpServers": {
     "org-mode": {
       "command": "nix",
-      "args": ["run", "github:szaffarano/org-mcp-server", "--", "--root", "/path/to/your/org/files"],
+      "args": ["run", "github:szaffarano/org-mcp-server"],
       "env": {}
     }
   }
 }
 #+end_src
 
-** Server Configuration
+** Environment Variable Configuration
 
-The server scans configured directories for =.org= files. Configuration is
-   handled through command-line arguments or environment variables
-   (implementation pending).
+You can configure the MCP server through environment variables in your agent configuration:
+
+#+begin_src json
+{
+  "mcpServers": {
+    "org-mode": {
+      "command": "/path/to/org-mcp-server",
+      "args": [],
+      "env": {
+        "ORG_ROOT_DIRECTORY": "/path/to/your/org/files",
+        "ORG_LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+#+end_src
 
 * Development
 
@@ -172,34 +238,6 @@ cargo clippy
 cargo run --example <name>
 #+end_src
 
-** Code Coverage
-
-The project includes comprehensive code coverage analysis using =cargo-llvm-cov=:
-
-#+begin_src bash
-# Quick coverage summary
-make coverage-summary
-
-# Generate HTML coverage report
-make coverage-html
-
-# Generate CI-compatible LCOV format
-make coverage-ci
-
-# Generate all coverage formats
-make coverage
-
-# Development workflow (format, lint, test, coverage)
-make dev
-#+end_src
-
-Coverage reports are generated in the =coverage/= directory:
-- =coverage/html/index.html= — Interactive HTML report
-- =coverage/lcov.info= — LCOV format for CI integration
-- =coverage/coverage.json= — JSON format for programmatic analysis
-
-*CI Integration*: Coverage is automatically calculated and reported on pull requests via GitHub Actions.
-
 * Roadmap
 
 ** Phase 1: Core Functionality ✅
@@ -212,10 +250,12 @@ Coverage reports are generated in the =coverage/= directory:
 - [X] Full-text search across org files
 
 ** Phase 2: Advanced Features 🚧
+- [X] Configuration file support with TOML format
+- [X] Environment variable configuration
+- [X] Unified CLI interface with global configuration
 - [ ] Tag-based filtering and querying
 - [ ] Link following and backlink discovery (org-roam support)
 - [ ] Metadata caching for performance
-- [ ] Configuration file support
 - [ ] Agenda-related Functionality
 
 ** Phase 3: Extended Capabilities 📋

--- a/mcp-server/src/core.rs
+++ b/mcp-server/src/core.rs
@@ -1,7 +1,7 @@
 use std::{error, sync::Arc};
 use tokio::sync::Mutex;
 
-use org_core::OrgMode;
+use org_core::{Config, OrgMode};
 use rmcp::handler::server::tool::ToolRouter;
 
 pub struct OrgModeRouter {
@@ -10,12 +10,19 @@ pub struct OrgModeRouter {
 }
 
 impl OrgModeRouter {
-    pub fn with_directory(org_dir: &str) -> Result<Self, Box<dyn error::Error>> {
-        let org_mode = OrgMode::new(org_dir)?;
+    pub fn with_config(config: Config) -> Result<Self, Box<dyn error::Error>> {
+        let org_mode = OrgMode::new(config)?;
         Ok(Self {
             org_mode: Arc::new(Mutex::new(org_mode)),
             tool_router: Self::tool_router(),
         })
+    }
+
+    pub fn with_directory(org_dir: &str) -> Result<Self, Box<dyn error::Error>> {
+        let mut config = Config::default();
+        config.org.org_directory = org_dir.to_string();
+        let config = config.validate()?;
+        Self::with_config(config)
     }
 
     fn tool_router() -> ToolRouter<Self> {

--- a/mcp-server/tests/integration_tests.rs
+++ b/mcp-server/tests/integration_tests.rs
@@ -45,7 +45,7 @@ macro_rules! create_mcp_service {
 
         let command = tokio::process::Command::new($crate::get_binary_path("org-mcp-server"))
             .configure(|cmd| {
-                cmd.args(["--root", $temp_dir.path().to_str().unwrap()]);
+                cmd.args(["--root-directory", $temp_dir.path().to_str().unwrap()]);
             });
 
         ().serve(TokioChildProcess::new(command)?)

--- a/mcp-server/tests/integration_tests/server_tests.rs
+++ b/mcp-server/tests/integration_tests/server_tests.rs
@@ -117,6 +117,8 @@ async fn test_mcp_server_with_config_file() -> Result<(), Box<dyn std::error::Er
     let temp_dir = setup_test_org_files()?;
     let config_path = temp_dir.path().join("test-config.toml");
 
+    // Convert path to forward slashes for TOML compatibility on Windows
+    let path_str = temp_dir.path().to_str().unwrap().replace('\\', "/");
     let config_content = format!(
         r#"
 [org]
@@ -125,7 +127,7 @@ org_directory = "{}"
 [logging]
 level = "debug"
 "#,
-        temp_dir.path().to_str().unwrap()
+        path_str
     );
     fs::write(&config_path, config_content)?;
 

--- a/mcp-server/tests/integration_tests/server_tests.rs
+++ b/mcp-server/tests/integration_tests/server_tests.rs
@@ -25,7 +25,7 @@ async fn test_graceful_close_mcp_server() -> Result<(), Box<dyn std::error::Erro
     let org_dir = setup_test_org_files()?;
     let binary = get_binary_path("org-mcp-server");
     let mut command = Command::new(binary).configure(|cmd| {
-        cmd.args(["--root", org_dir.path().to_str().unwrap()]);
+        cmd.args(["--root-directory", org_dir.path().to_str().unwrap()]);
     });
 
     let mut child = command.stdin(std::process::Stdio::piped()).spawn()?;

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -1,14 +1,15 @@
 [dependencies]
-org-core = {path = "../org-core"}
-clap = {workspace = true, features = ["derive"]}
-anyhow = {workspace = true}
-serde_json = {workspace = true}
-shellexpand = {workspace = true}
+org-core = { path = "../org-core" }
+clap = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+shellexpand = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = {workspace = true}
-predicates = {workspace = true}
-tempfile = {workspace = true}
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
+tempfile = { workspace = true }
 
 [package]
 name = "org-cli"

--- a/org-cli/src/commands/config.rs
+++ b/org-cli/src/commands/config.rs
@@ -19,16 +19,20 @@ enum ConfigAction {
 }
 
 impl ConfigCommand {
-    pub fn execute(&self) -> Result<()> {
+    pub fn execute(&self, config_file: Option<String>) -> Result<()> {
         match &self.action {
-            ConfigAction::Init => self.init_config(),
-            ConfigAction::Show => self.show_config(),
-            ConfigAction::Path => self.show_path(),
+            ConfigAction::Init => self.init_config(config_file),
+            ConfigAction::Show => self.show_config(config_file),
+            ConfigAction::Path => self.show_path(config_file),
         }
     }
 
-    fn init_config(&self) -> Result<()> {
-        let config_path = Config::default_config_path()?;
+    fn init_config(&self, config_file: Option<String>) -> Result<()> {
+        let config_path = if let Some(path) = config_file {
+            std::path::PathBuf::from(path)
+        } else {
+            Config::default_config_path()?
+        };
 
         if config_path.exists() {
             println!(
@@ -51,15 +55,20 @@ impl ConfigCommand {
         Ok(())
     }
 
-    fn show_config(&self) -> Result<()> {
-        let config = Config::load().unwrap_or_else(|_| Config::default());
+    fn show_config(&self, config_file: Option<String>) -> Result<()> {
+        let config = Config::load_with_overrides(config_file, None, None)
+            .unwrap_or_else(|_| Config::default());
         let config_toml = toml::to_string_pretty(&config)?;
         println!("{}", config_toml);
         Ok(())
     }
 
-    fn show_path(&self) -> Result<()> {
-        let config_path = Config::default_config_path()?;
+    fn show_path(&self, config_file: Option<String>) -> Result<()> {
+        let config_path = if let Some(path) = config_file {
+            std::path::PathBuf::from(path)
+        } else {
+            Config::default_config_path()?
+        };
         println!("{}", config_path.display());
         Ok(())
     }

--- a/org-cli/src/commands/config.rs
+++ b/org-cli/src/commands/config.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use org_core::Config;
+
+#[derive(Args)]
+pub struct ConfigCommand {
+    #[command(subcommand)]
+    action: ConfigAction,
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Initialize a default configuration file
+    Init,
+    /// Show current configuration
+    Show,
+    /// Show configuration file path
+    Path,
+}
+
+impl ConfigCommand {
+    pub fn execute(&self) -> Result<()> {
+        match &self.action {
+            ConfigAction::Init => self.init_config(),
+            ConfigAction::Show => self.show_config(),
+            ConfigAction::Path => self.show_path(),
+        }
+    }
+
+    fn init_config(&self) -> Result<()> {
+        let config_path = Config::default_config_path()?;
+
+        if config_path.exists() {
+            println!(
+                "Configuration file already exists at: {}",
+                config_path.display()
+            );
+            println!("Use 'org config show' to view current configuration");
+            return Ok(());
+        }
+
+        let default_config = Config::default();
+        default_config.save_to_file(&config_path)?;
+
+        println!(
+            "Default configuration file created at: {}",
+            config_path.display()
+        );
+        println!("Edit this file to customize your org-mode setup");
+
+        Ok(())
+    }
+
+    fn show_config(&self) -> Result<()> {
+        let config = Config::load().unwrap_or_else(|_| Config::default());
+        let config_toml = toml::to_string_pretty(&config)?;
+        println!("{}", config_toml);
+        Ok(())
+    }
+
+    fn show_path(&self) -> Result<()> {
+        let config_path = Config::default_config_path()?;
+        println!("{}", config_path.display());
+        Ok(())
+    }
+}

--- a/org-cli/src/commands/element_by_id.rs
+++ b/org-cli/src/commands/element_by_id.rs
@@ -6,15 +6,10 @@ use org_core::OrgMode;
 pub struct ElementByIdCommand {
     /// The ID of the element to extract
     id: String,
-
-    /// Directory containing org files
-    #[arg(short, long, default_value = "~/org/")]
-    dir: String,
 }
 
 impl ElementByIdCommand {
-    pub fn execute(&self) -> Result<()> {
-        let org_mode = OrgMode::new(&self.dir)?;
+    pub fn execute(&self, org_mode: OrgMode) -> Result<()> {
         let content = org_mode.get_element_by_id(&self.id)?;
         println!("{}", content);
         Ok(())

--- a/org-cli/src/commands/heading.rs
+++ b/org-cli/src/commands/heading.rs
@@ -9,15 +9,10 @@ pub struct HeadingCommand {
 
     /// The heading to extract (without the * prefix)
     heading: String,
-
-    /// Directory containing org files
-    #[arg(short, long, default_value = "~/org/")]
-    dir: String,
 }
 
 impl HeadingCommand {
-    pub fn execute(&self) -> Result<()> {
-        let org_mode = OrgMode::new(&self.dir)?;
+    pub fn execute(&self, org_mode: OrgMode) -> Result<()> {
         let content = org_mode.get_heading(&self.file, &self.heading)?;
         println!("{}", content);
         Ok(())

--- a/org-cli/src/commands/list.rs
+++ b/org-cli/src/commands/list.rs
@@ -4,13 +4,9 @@ use org_core::OrgMode;
 
 #[derive(Args)]
 pub struct ListCommand {
-    /// Directory to search for org files
-    #[arg(short, long, default_value = "~/org/")]
-    dir: String,
-
     /// Output format
-    #[arg(short, long, default_value = "plain")]
-    format: OutputFormat,
+    #[arg(short, long)]
+    format: Option<OutputFormat>,
 }
 
 #[derive(clap::ValueEnum, Clone)]
@@ -20,16 +16,29 @@ enum OutputFormat {
 }
 
 impl ListCommand {
-    pub fn execute(&self) -> Result<()> {
-        let org_mode = OrgMode::new(&self.dir)?;
+    pub fn execute(&self, org_mode: OrgMode) -> Result<()> {
         let files = org_mode.list_files()?;
 
-        match self.format {
+        let format = self.format.as_ref().unwrap_or({
+            match org_mode.config().cli.default_format.as_str() {
+                "json" => &OutputFormat::Json,
+                _ => &OutputFormat::Plain,
+            }
+        });
+
+        match format {
             OutputFormat::Plain => {
                 if files.is_empty() {
-                    println!("No .org files found in {}", self.dir);
+                    println!(
+                        "No .org files found in {}",
+                        org_mode.config().org.org_directory
+                    );
                 } else {
-                    println!("Found {} .org files in {}:", files.len(), self.dir);
+                    println!(
+                        "Found {} .org files in {}:",
+                        files.len(),
+                        org_mode.config().org.org_directory
+                    );
                     for file in files {
                         println!("  {file}");
                     }
@@ -37,7 +46,7 @@ impl ListCommand {
             }
             OutputFormat::Json => {
                 let json = serde_json::json!({
-                    "directory": self.dir,
+                    "directory": org_mode.config().org.org_directory,
                     "count": files.len(),
                     "files": files
                 });

--- a/org-cli/src/commands/mod.rs
+++ b/org-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod element_by_id;
 pub mod heading;
 pub mod init;
@@ -6,6 +7,7 @@ pub mod outline;
 pub mod read;
 pub mod search;
 
+pub use config::ConfigCommand;
 pub use element_by_id::ElementByIdCommand;
 pub use heading::HeadingCommand;
 pub use init::InitCommand;

--- a/org-cli/src/commands/read.rs
+++ b/org-cli/src/commands/read.rs
@@ -6,15 +6,10 @@ use org_core::OrgMode;
 pub struct ReadCommand {
     /// Relative path to the org file to read
     file: String,
-
-    /// Directory containing org files
-    #[arg(short, long, default_value = "~/org/")]
-    dir: String,
 }
 
 impl ReadCommand {
-    pub fn execute(&self) -> Result<()> {
-        let org_mode = OrgMode::new(&self.dir)?;
+    pub fn execute(&self, org_mode: OrgMode) -> Result<()> {
         let content = org_mode.read_file(&self.file)?;
         println!("{}", content);
         Ok(())

--- a/org-cli/src/main.rs
+++ b/org-cli/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Config(cmd) => cmd.execute(),
+        Commands::Config(cmd) => cmd.execute(cli.config),
         _ => {
             // Load configuration with CLI overrides for non-config commands
             let config = Config::load_with_overrides(

--- a/org-cli/src/main.rs
+++ b/org-cli/src/main.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use org_core::{Config, OrgMode};
 
 mod commands;
 use commands::{
-    ElementByIdCommand, HeadingCommand, InitCommand, ListCommand, OutlineCommand, ReadCommand,
-    SearchCommand,
+    ConfigCommand, ElementByIdCommand, HeadingCommand, InitCommand, ListCommand, OutlineCommand,
+    ReadCommand, SearchCommand,
 };
 
 #[derive(Parser)]
@@ -12,12 +13,22 @@ use commands::{
 #[command(about = "A CLI tool for org-mode functionality")]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
+    /// Path to configuration file
+    #[arg(short, long)]
+    config: Option<String>,
+
+    /// Root directory containing org-mode files
+    #[arg(short, long)]
+    root_directory: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Configuration management
+    Config(ConfigCommand),
     /// List all .org files in a directory
     List(ListCommand),
     /// Initialize or validate an org directory
@@ -38,12 +49,26 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::List(cmd) => cmd.execute(),
-        Commands::Init(cmd) => cmd.execute(),
-        Commands::Read(cmd) => cmd.execute(),
-        Commands::Outline(cmd) => cmd.execute(),
-        Commands::Heading(cmd) => cmd.execute(),
-        Commands::ElementById(cmd) => cmd.execute(),
-        Commands::Search(cmd) => cmd.execute(),
+        Commands::Config(cmd) => cmd.execute(),
+        _ => {
+            // Load configuration with CLI overrides for non-config commands
+            let config = Config::load_with_overrides(
+                cli.config,
+                cli.root_directory,
+                None, // log_level not needed for CLI
+            )?;
+
+            let org_mode = OrgMode::new(config)?;
+            match cli.command {
+                Commands::Config(_) => unreachable!(),
+                Commands::List(cmd) => cmd.execute(org_mode),
+                Commands::Init(cmd) => cmd.execute(org_mode),
+                Commands::Read(cmd) => cmd.execute(org_mode),
+                Commands::Outline(cmd) => cmd.execute(org_mode),
+                Commands::Heading(cmd) => cmd.execute(org_mode),
+                Commands::ElementById(cmd) => cmd.execute(org_mode),
+                Commands::Search(cmd) => cmd.execute(org_mode),
+            }
+        }
     }
 }

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -73,9 +73,9 @@ fn test_list_command_basic() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("list")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("list")
         .assert()
         .success()
         .stdout(predicate::str::contains("Found 4 .org files"))
@@ -91,9 +91,9 @@ fn test_list_command_json_format() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("list")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("list")
         .arg("--format")
         .arg("json")
         .assert()
@@ -109,9 +109,9 @@ fn test_list_command_empty_directory() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("list")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("list")
         .assert()
         .success()
         .stdout(predicate::str::contains("No .org files found"));
@@ -120,12 +120,12 @@ fn test_list_command_empty_directory() {
 #[test]
 fn test_list_command_invalid_directory() {
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("list")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg("/nonexistent/directory")
+        .arg("list")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Directory does not exist"));
+        .stderr(predicate::str::contains("Root directory does not exist"));
 }
 
 #[test]
@@ -134,10 +134,10 @@ fn test_read_command_basic() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("read")
-        .arg("basic.org")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("read")
+        .arg("basic.org")
         .assert()
         .success()
         .stdout(predicate::str::contains("* First Heading"))
@@ -151,10 +151,10 @@ fn test_read_command_nonexistent_file() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("read")
-        .arg("nonexistent.org")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("read")
+        .arg("nonexistent.org")
         .assert()
         .failure();
 }
@@ -165,10 +165,10 @@ fn test_outline_command_basic() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("outline")
-        .arg("basic.org")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("outline")
+        .arg("basic.org")
         .assert()
         .success()
         .stdout(predicate::str::contains("* First Heading"))
@@ -182,10 +182,10 @@ fn test_outline_command_json_format() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("outline")
-        .arg("basic.org")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("outline")
+        .arg("basic.org")
         .arg("--format")
         .arg("json")
         .assert()
@@ -201,11 +201,11 @@ fn test_heading_command_basic() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("heading")
+    cmd.arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("heading")
         .arg("basic.org")
         .arg("First Heading")
-        .arg("--dir")
-        .arg(temp_dir.path().to_str().unwrap())
         .assert()
         .success()
         .stdout(predicate::str::contains("* First Heading"))
@@ -220,11 +220,11 @@ fn test_heading_command_nested() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("heading")
+    cmd.arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("heading")
         .arg("basic.org")
         .arg("First Heading/Sub Heading")
-        .arg("--dir")
-        .arg(temp_dir.path().to_str().unwrap())
         .assert()
         .success()
         .stdout(predicate::str::contains("** Sub Heading"))
@@ -237,11 +237,11 @@ fn test_heading_command_nonexistent() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("heading")
+    cmd.arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("heading")
         .arg("basic.org")
         .arg("Nonexistent Heading")
-        .arg("--dir")
-        .arg(temp_dir.path().to_str().unwrap())
         .assert()
         .failure()
         .stderr(predicate::str::contains("Invalid heading"));
@@ -253,10 +253,10 @@ fn test_element_by_id_command_heading() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("element-by-id")
-        .arg("heading-123")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("element-by-id")
+        .arg("heading-123")
         .assert()
         .success()
         .stdout(predicate::str::contains("* First Heading"))
@@ -271,10 +271,10 @@ fn test_element_by_id_command_document_level() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("element-by-id")
-        .arg("doc-id-789")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("element-by-id")
+        .arg("doc-id-789")
         .assert()
         .success()
         .stdout(predicate::str::contains(":ID: doc-id-789"))
@@ -287,10 +287,10 @@ fn test_element_by_id_command_nonexistent() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("element-by-id")
-        .arg("nonexistent-id")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("element-by-id")
+        .arg("nonexistent-id")
         .assert()
         .failure()
         .stderr(predicate::str::contains("Invalid element id"));
@@ -301,6 +301,7 @@ fn test_init_command_basic() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("ORG_ROOT_DIRECTORY", temp_dir.path().to_str().unwrap());
     cmd.arg("init")
         .arg(temp_dir.path().to_str().unwrap())
         .assert()
@@ -316,6 +317,7 @@ fn test_init_command_existing_directory() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("ORG_ROOT_DIRECTORY", temp_dir.path().to_str().unwrap());
     cmd.arg("init")
         .arg(temp_dir.path().to_str().unwrap())
         .assert()
@@ -361,10 +363,10 @@ fn test_search_command_basic() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("project")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("project")
         .assert()
         .success()
         .stdout(predicate::str::contains("Found"))
@@ -378,10 +380,10 @@ fn test_search_command_with_limit() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("bug")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("bug")
         .arg("--limit")
         .arg("1")
         .assert()
@@ -395,10 +397,10 @@ fn test_search_command_json_format() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("heading")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("heading")
         .arg("--format")
         .arg("json")
         .assert()
@@ -418,10 +420,10 @@ fn test_search_command_custom_snippet_size() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("truncated")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("truncated")
         .arg("--snippet-size")
         .arg("20")
         .assert()
@@ -437,10 +439,10 @@ fn test_search_command_no_results() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("nonexistentquerythatwillnotmatch")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("nonexistentquerythatwillnotmatch")
         .assert()
         .success()
         .stdout(predicate::str::contains("No results found"));
@@ -452,10 +454,10 @@ fn test_search_command_empty_query() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("")
         .assert()
         .success()
         .stdout(predicate::str::contains("No results found"));
@@ -464,13 +466,13 @@ fn test_search_command_empty_query() {
 #[test]
 fn test_search_command_invalid_directory() {
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("test")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg("/nonexistent/directory")
+        .arg("search")
+        .arg("test")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Directory does not exist"));
+        .stderr(predicate::str::contains("Root directory does not exist"));
 }
 
 #[test]
@@ -479,10 +481,10 @@ fn test_search_command_all_parameters() {
     create_test_org_files(&temp_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("org-cli").unwrap();
-    cmd.arg("search")
-        .arg("content")
-        .arg("--dir")
+    cmd.arg("--root-directory")
         .arg(temp_dir.path().to_str().unwrap())
+        .arg("search")
+        .arg("content")
         .arg("--limit")
         .arg("2")
         .arg("--format")
@@ -504,7 +506,6 @@ fn test_search_command_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Search for text content"))
-        .stdout(predicate::str::contains("--dir"))
         .stdout(predicate::str::contains("--limit"))
         .stdout(predicate::str::contains("--format"))
         .stdout(predicate::str::contains("--snippet-size"));

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -510,3 +510,145 @@ fn test_search_command_help() {
         .stdout(predicate::str::contains("--format"))
         .stdout(predicate::str::contains("--snippet-size"));
 }
+
+#[test]
+fn test_config_init_creates_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("org-mcp-server.toml");
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap())
+        .arg("config")
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Default configuration file created",
+        ))
+        .stdout(predicate::str::contains(config_path.to_str().unwrap()));
+
+    assert!(config_path.exists());
+}
+
+#[test]
+fn test_config_init_file_already_exists() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("org-mcp-server.toml");
+
+    fs::write(&config_path, "[org]\norg_directory = \"/test\"").unwrap();
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap())
+        .arg("config")
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already exists"))
+        .stdout(predicate::str::contains("Use 'org config show'"));
+}
+
+#[test]
+fn test_config_show_displays_config() {
+    let temp_dir = TempDir::new().unwrap();
+    create_test_org_files(&temp_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("ORG_ROOT_DIRECTORY", temp_dir.path().to_str().unwrap())
+        .arg("config")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[org]"))
+        .stdout(predicate::str::contains("org_directory"))
+        .stdout(predicate::str::contains("[logging]"))
+        .stdout(predicate::str::contains("[cli]"));
+}
+
+#[test]
+fn test_config_show_fallback_to_default() {
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("XDG_CONFIG_HOME", "/nonexistent/path")
+        .arg("config")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("~/org/"))
+        .stdout(predicate::str::contains("notes.org"));
+}
+
+#[test]
+fn test_config_path_shows_location() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap())
+        .arg("config")
+        .arg("path")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("org-mcp-server.toml"));
+}
+
+#[test]
+fn test_config_file_affects_list_output() {
+    let temp_dir = TempDir::new().unwrap();
+    create_test_org_files(&temp_dir).unwrap();
+
+    let config_path = temp_dir.path().join("config.toml");
+    let config_content = format!(
+        r#"
+[org]
+org_directory = "{}"
+
+[cli]
+default_format = "json"
+"#,
+        temp_dir.path().to_str().unwrap()
+    );
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.arg("--config")
+        .arg(config_path.to_str().unwrap())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{"))
+        .stdout(predicate::str::contains("\"directory\""))
+        .stdout(predicate::str::contains("\"count\""));
+}
+
+#[test]
+fn test_config_hierarchy_file_env_cli() {
+    let temp_dir = TempDir::new().unwrap();
+    create_test_org_files(&temp_dir).unwrap();
+
+    let config_dir = TempDir::new().unwrap();
+    let config_path = config_dir.path().join("config.toml");
+
+    let config_content = format!(
+        r#"
+[org]
+org_directory = "{}"
+
+[logging]
+level = "info"
+
+[cli]
+default_format = "plain"
+"#,
+        temp_dir.path().to_str().unwrap()
+    );
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("org-cli").unwrap();
+    cmd.env("ORG_LOG_LEVEL", "debug")
+        .env("ORG_ROOT_DIRECTORY", temp_dir.path().to_str().unwrap())
+        .arg("--config")
+        .arg(config_path.to_str().unwrap())
+        .arg("config")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("level = \"debug\""));
+}

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -633,6 +633,8 @@ fn test_config_show_with_explicit_path() {
     create_test_org_files(&temp_dir).unwrap();
 
     let config_path = temp_dir.path().join("test-config.toml");
+    // Convert path to forward slashes for TOML compatibility on Windows
+    let path_str = temp_dir.path().to_str().unwrap().replace('\\', "/");
     let config_content = format!(
         r#"
 [org]
@@ -644,7 +646,7 @@ level = "debug"
 [cli]
 default_format = "plain"
 "#,
-        temp_dir.path().to_str().unwrap()
+        path_str
     );
     fs::write(&config_path, config_content).unwrap();
 
@@ -681,6 +683,8 @@ fn test_config_file_affects_list_output() {
     create_test_org_files(&temp_dir).unwrap();
 
     let config_path = temp_dir.path().join("config.toml");
+    // Convert path to forward slashes for TOML compatibility on Windows
+    let path_str = temp_dir.path().to_str().unwrap().replace('\\', "/");
     let config_content = format!(
         r#"
 [org]
@@ -689,7 +693,7 @@ org_directory = "{}"
 [cli]
 default_format = "json"
 "#,
-        temp_dir.path().to_str().unwrap()
+        path_str
     );
     fs::write(&config_path, config_content).unwrap();
 
@@ -712,6 +716,8 @@ fn test_config_hierarchy_file_env_cli() {
     let config_dir = TempDir::new().unwrap();
     let config_path = config_dir.path().join("config.toml");
 
+    // Convert path to forward slashes for TOML compatibility on Windows
+    let path_str = temp_dir.path().to_str().unwrap().replace('\\', "/");
     let config_content = format!(
         r#"
 [org]
@@ -723,7 +729,7 @@ level = "info"
 [cli]
 default_format = "plain"
 "#,
-        temp_dir.path().to_str().unwrap()
+        path_str
     );
     fs::write(&config_path, config_content).unwrap();
 
@@ -811,6 +817,8 @@ fn test_config_show_with_home_env() {
     fs::create_dir_all(&config_dir).unwrap();
 
     let config_path = config_dir.join("org-mcp-server.toml");
+    // Convert path to forward slashes for TOML compatibility on Windows
+    let path_str = temp_org.path().to_str().unwrap().replace('\\', "/");
     let config_content = format!(
         r#"
 [org]
@@ -819,7 +827,7 @@ org_directory = "{}"
 [logging]
 level = "trace"
 "#,
-        temp_org.path().to_str().unwrap()
+        path_str
     );
     fs::write(&config_path, config_content).unwrap();
 

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -1,15 +1,17 @@
 [dependencies]
-nucleo-matcher = "0.3"
-orgize = {workspace = true, features = ["tracing"]}
-serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
-shellexpand = {workspace = true}
-tracing = {workspace = true}
-walkdir = {workspace = true}
+orgize = { workspace = true, features = ["tracing"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+shellexpand = { workspace = true }
+tracing = { workspace = true }
+walkdir = { workspace = true }
+toml = { workspace = true }
+dirs = { workspace = true }
+nucleo-matcher = { workspace = true }
 
 [dev-dependencies]
-tracing-subscriber = {workspace = true, features = ["fmt"]}
-tempfile = {workspace = true}
+tracing-subscriber = { workspace = true, features = ["fmt"] }
+tempfile = { workspace = true }
 
 [package]
 name = "org-core"

--- a/org-core/src/config.rs
+++ b/org-core/src/config.rs
@@ -1,0 +1,385 @@
+use std::{env, fs, io, path::PathBuf};
+
+use crate::OrgModeError;
+use serde::{Deserialize, Serialize};
+use shellexpand::tilde;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub org: OrgConfig,
+    #[serde(default)]
+    pub logging: LoggingConfig,
+    #[serde(default)]
+    pub cli: CliConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgConfig {
+    #[serde(default = "default_org_directory")]
+    pub org_directory: String,
+    #[serde(default = "default_notes_file")]
+    pub org_default_notes_file: String,
+    #[serde(default = "default_agenda_files")]
+    pub org_agenda_files: Vec<String>,
+    #[serde(default)]
+    pub org_agenda_text_search_extra_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoggingConfig {
+    #[serde(default = "default_log_level")]
+    pub level: String,
+    #[serde(default = "default_log_file")]
+    pub file: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliConfig {
+    #[serde(default = "default_output_format")]
+    pub default_format: String,
+}
+
+fn default_org_directory() -> String {
+    "~/org/".to_string()
+}
+
+fn default_notes_file() -> String {
+    "notes.org".to_string()
+}
+
+fn default_agenda_files() -> Vec<String> {
+    vec!["agenda.org".to_string()]
+}
+
+fn default_log_level() -> String {
+    "info".to_string()
+}
+
+fn default_log_file() -> String {
+    "~/.local/share/org-mcp-server/logs/server.log".to_string()
+}
+
+fn default_output_format() -> String {
+    "plain".to_string()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            org: OrgConfig {
+                org_directory: default_org_directory(),
+                org_default_notes_file: default_notes_file(),
+                org_agenda_files: default_agenda_files(),
+                org_agenda_text_search_extra_files: Vec::default(),
+            },
+            logging: LoggingConfig::default(),
+            cli: CliConfig::default(),
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: default_log_level(),
+            file: default_log_file(),
+        }
+    }
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        Self {
+            default_format: default_output_format(),
+        }
+    }
+}
+
+pub struct ConfigBuilder {
+    config: Config,
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: Config::default(),
+        }
+    }
+
+    pub fn with_config_file(mut self, config_path: Option<&str>) -> Result<Self, OrgModeError> {
+        let config_file = if let Some(path) = config_path {
+            PathBuf::from(path)
+        } else {
+            self.default_config_path()?
+        };
+
+        if config_file.exists() {
+            let content = std::fs::read_to_string(&config_file).map_err(|e| {
+                OrgModeError::ConfigError(format!(
+                    "Failed to read config file {config_file:?}: {e}"
+                ))
+            })?;
+
+            self.config = toml::from_str(&content).map_err(|e| {
+                OrgModeError::ConfigError(format!(
+                    "Failed to parse config file {config_file:?}: {e}"
+                ))
+            })?;
+        }
+
+        Ok(self)
+    }
+
+    pub fn with_env_vars(mut self) -> Self {
+        if let Ok(root_dir) = env::var("ORG_ROOT_DIRECTORY") {
+            self.config.org.org_directory = root_dir;
+        }
+
+        if let Ok(notes_file) = env::var("ORG_DEFAULT_NOTES_FILE") {
+            self.config.org.org_default_notes_file = notes_file;
+        }
+
+        if let Ok(agenda_files) = env::var("ORG_AGENDA_FILES") {
+            self.config.org.org_agenda_files = agenda_files
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect();
+        }
+
+        if let Ok(extra_files) = env::var("ORG_AGENDA_TEXT_SEARCH_EXTRA_FILES") {
+            self.config.org.org_agenda_text_search_extra_files = extra_files
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect();
+        }
+
+        if let Ok(log_level) = env::var("ORG_LOG_LEVEL") {
+            self.config.logging.level = log_level;
+        }
+
+        if let Ok(log_file) = env::var("ORG_LOG_FILE") {
+            self.config.logging.file = log_file;
+        }
+
+        self
+    }
+
+    pub fn with_cli_overrides(
+        mut self,
+        root_directory: Option<String>,
+        log_level: Option<String>,
+    ) -> Self {
+        if let Some(root_dir) = root_directory {
+            self.config.org.org_directory = root_dir;
+        }
+
+        if let Some(level) = log_level {
+            self.config.logging.level = level;
+        }
+
+        self
+    }
+
+    pub fn build(self) -> Config {
+        self.config
+    }
+
+    fn default_config_path(&self) -> Result<PathBuf, OrgModeError> {
+        let config_dir = dirs::config_dir().ok_or_else(|| {
+            OrgModeError::ConfigError("Could not determine config directory".to_string())
+        })?;
+
+        Ok(config_dir.join("org-mcp-server.toml"))
+    }
+}
+
+impl Config {
+    pub fn load() -> Result<Self, OrgModeError> {
+        ConfigBuilder::new()
+            .with_config_file(None)?
+            .with_env_vars()
+            .build()
+            .validate()
+    }
+
+    pub fn load_with_overrides(
+        config_file: Option<String>,
+        root_directory: Option<String>,
+        log_level: Option<String>,
+    ) -> Result<Self, OrgModeError> {
+        ConfigBuilder::new()
+            .with_config_file(config_file.as_deref())?
+            .with_env_vars()
+            .with_cli_overrides(root_directory, log_level)
+            .build()
+            .validate()
+    }
+
+    pub fn validate(mut self) -> Result<Self, OrgModeError> {
+        let expanded_root = tilde(&self.org.org_directory);
+        let root_path = PathBuf::from(expanded_root.as_ref());
+
+        if !root_path.exists() {
+            return Err(OrgModeError::ConfigError(format!(
+                "Root directory does not exist: {}",
+                self.org.org_directory
+            )));
+        }
+
+        if !root_path.is_dir() {
+            return Err(OrgModeError::ConfigError(format!(
+                "Root directory is not a directory: {}",
+                self.org.org_directory
+            )));
+        }
+
+        match fs::read_dir(&root_path) {
+            Ok(_) => {}
+            Err(e) => {
+                if e.kind() == io::ErrorKind::PermissionDenied {
+                    return Err(OrgModeError::InvalidDirectory(format!(
+                        "Permission denied accessing directory: {root_path:?}"
+                    )));
+                }
+                return Err(OrgModeError::IoError(e));
+            }
+        }
+
+        self.org.org_directory = expanded_root.to_string();
+        Ok(self)
+    }
+
+    pub fn generate_default_config() -> Result<String, OrgModeError> {
+        let config = Config::default();
+        toml::to_string_pretty(&config).map_err(|e| {
+            OrgModeError::ConfigError(format!("Failed to serialize default config: {e}"))
+        })
+    }
+
+    pub fn default_config_path() -> Result<PathBuf, OrgModeError> {
+        let config_dir = dirs::config_dir().ok_or_else(|| {
+            OrgModeError::ConfigError("Could not determine config directory".to_string())
+        })?;
+
+        Ok(config_dir.join("org-mcp-server.toml"))
+    }
+
+    pub fn save_to_file(&self, path: &PathBuf) -> Result<(), OrgModeError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                OrgModeError::ConfigError(format!("Failed to create config directory: {e}"))
+            })?;
+        }
+
+        let content = toml::to_string_pretty(self)
+            .map_err(|e| OrgModeError::ConfigError(format!("Failed to serialize config: {e}")))?;
+
+        std::fs::write(path, content)
+            .map_err(|e| OrgModeError::ConfigError(format!("Failed to write config file: {e}")))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default();
+        assert_eq!(config.org.org_directory, "~/org/");
+        assert_eq!(config.org.org_default_notes_file, "notes.org");
+        assert_eq!(config.org.org_agenda_files, vec!["agenda.org"]);
+        assert!(config.org.org_agenda_text_search_extra_files.is_empty());
+        assert_eq!(config.logging.level, "info");
+        assert_eq!(config.cli.default_format, "plain");
+    }
+
+    #[test]
+    fn test_config_serialization() {
+        let config = Config::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(config.org.org_directory, parsed.org.org_directory);
+        assert_eq!(
+            config.org.org_default_notes_file,
+            parsed.org.org_default_notes_file
+        );
+        assert_eq!(config.org.org_agenda_files, parsed.org.org_agenda_files);
+    }
+
+    #[test]
+    fn test_env_var_override() {
+        unsafe {
+            env::set_var("ORG_ROOT_DIRECTORY", "/tmp/test-org");
+            env::set_var("ORG_DEFAULT_NOTES_FILE", "test-notes.org");
+            env::set_var("ORG_AGENDA_FILES", "agenda1.org,agenda2.org");
+        }
+
+        let config = ConfigBuilder::new().with_env_vars().build();
+
+        assert_eq!(config.org.org_directory, "/tmp/test-org");
+        assert_eq!(config.org.org_default_notes_file, "test-notes.org");
+        assert_eq!(
+            config.org.org_agenda_files,
+            vec!["agenda1.org", "agenda2.org"]
+        );
+
+        unsafe {
+            env::remove_var("ORG_ROOT_DIRECTORY");
+            env::remove_var("ORG_DEFAULT_NOTES_FILE");
+            env::remove_var("ORG_AGENDA_FILES");
+        }
+    }
+
+    #[test]
+    fn test_cli_override() {
+        let config = ConfigBuilder::new()
+            .with_cli_overrides(Some("/custom/org".to_string()), Some("debug".to_string()))
+            .build();
+
+        assert_eq!(config.org.org_directory, "/custom/org");
+        assert_eq!(config.logging.level, "debug");
+    }
+
+    #[test]
+    fn test_config_file_loading() {
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path().join("test-config.toml");
+
+        let test_config = r#"
+[org]
+org_directory = "/test/org"
+org_default_notes_file = "custom-notes.org"
+org_agenda_files = ["test1.org", "test2.org"]
+
+[logging]
+level = "debug"
+
+[cli]
+default_format = "json"
+"#;
+
+        std::fs::write(&config_path, test_config).unwrap();
+
+        let config = ConfigBuilder::new()
+            .with_config_file(Some(config_path.to_str().unwrap()))
+            .unwrap()
+            .build();
+
+        assert_eq!(config.org.org_directory, "/test/org");
+        assert_eq!(config.org.org_default_notes_file, "custom-notes.org");
+        assert_eq!(config.org.org_agenda_files, vec!["test1.org", "test2.org"]);
+        assert_eq!(config.logging.level, "debug");
+        assert_eq!(config.cli.default_format, "json");
+    }
+}

--- a/org-core/src/error.rs
+++ b/org-core/src/error.rs
@@ -8,6 +8,7 @@ pub enum OrgModeError {
     WalkDirError(walkdir::Error),
     IoError(std::io::Error),
     ShellExpansionError(String),
+    ConfigError(String),
 }
 
 impl fmt::Display for OrgModeError {
@@ -25,6 +26,7 @@ impl fmt::Display for OrgModeError {
             OrgModeError::WalkDirError(err) => write!(f, "Error walking directory: {err}"),
             OrgModeError::IoError(err) => write!(f, "IO error: {err}"),
             OrgModeError::ShellExpansionError(path) => write!(f, "Failed to expand path: {path}"),
+            OrgModeError::ConfigError(msg) => write!(f, "Configuration error: {msg}"),
         }
     }
 }

--- a/org-core/src/lib.rs
+++ b/org-core/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod config;
 pub mod error;
 pub mod org_mode;
 
 #[cfg(test)]
 mod error_tests;
 
+pub use config::Config;
 pub use error::OrgModeError;
 pub use org_mode::OrgMode;

--- a/org-core/src/org_mode_tests.rs
+++ b/org-core/src/org_mode_tests.rs
@@ -1,9 +1,10 @@
 use crate::org_mode::TreeNode;
-use crate::{OrgMode, OrgModeError};
+use crate::{Config, OrgMode, OrgModeError};
 
 fn create_test_org_mode() -> OrgMode {
-    let test_dir = "tests/fixtures";
-    OrgMode::new(test_dir).expect("Failed to create test OrgMode")
+    let mut config = Config::default();
+    config.org.org_directory = "tests/fixtures".to_string();
+    OrgMode::new(config).expect("Failed to create test OrgMode")
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Implement comprehensive configuration management for org-mode settings

- Add Config struct with org-mode, logging, and CLI configuration sections
- Create `org config` CLI command with init/show/path subcommands
- Support XDG config directory (~/.config/org-mcp-server.toml)
- Integrate configuration into all CLI commands and MCP server
- Support environment variable overrides for org settings
- Update documentation with configuration examples

Fixes #29 

## Test plan
- [x] Test `org config init` creates default config file
- [x] Test `org config show` displays current configuration
- [x] Test `org config path` shows config file location
- [x] Verify environment variable overrides work correctly
- [x] Verify all CLI commands respect configuration settings