### PR TITLE
test(core): fix flaky config tests with proper env isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,7 +900,9 @@ dependencies = [
  "orgize",
  "serde",
  "serde_json",
+ "serial_test",
  "shellexpand",
+ "temp-env",
  "tempfile",
  "toml",
  "tracing",
@@ -912,6 +923,29 @@ dependencies = [
  "nom",
  "rowan",
  "tracing",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1042,6 +1076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1208,6 +1251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1284,18 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -1294,6 +1358,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1369,6 +1458,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,14 @@ resolver = "3"
 members = ["mcp-server", "org-cli", "org-core"]
 
 [workspace.dependencies]
-nucleo-matcher = "0.3"
-orgize = { version = "0.10.0-alpha.10", features = ["tracing"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.145"
-shellexpand = "3.1.1"
-tracing = "0.1.41"
-walkdir = "2.5"
-clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 assert_cmd = "2.0"
+clap = { version = "4.5", features = ["derive"] }
 dirs = "6"
-toml = "0.9"
-predicates = "3.1"
-tempfile = "3.23"
+nucleo-matcher = "0.3"
 org-core = { version = "0.1.0", path = "../org-core" }
+orgize = { version = "0.10.0-alpha.10", features = ["tracing"] }
+predicates = "3.1"
 rmcp = { version = "0.8.0", features = [
   "transport-io",
   "transport-child-process",
@@ -33,6 +26,12 @@ rmcp = { version = "0.8.0", features = [
   "transport-worker",
   "client",
 ] }
+serde_json = "1.0.145"
+serde = { version = "1.0", features = ["derive"] }
+serial_test = "3.2.0"
+shellexpand = "3.1.1"
+tempfile = "3.23"
+tokio-test = "0.4"
 tokio = { version = "1", features = [
   "io-std",
   "macros",
@@ -41,15 +40,17 @@ tokio = { version = "1", features = [
   "rt-multi-thread",
   "signal",
 ] }
+toml = "0.9"
+tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.20", features = [
   "env-filter",
   "std",
   "fmt",
 ] }
-urlencoding = "2.1"
-tokio-test = "0.4"
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
+urlencoding = "2.1"
+walkdir = "2.5"
 
 [workspace.metadata.coverage]
 exclude = ["*/tests/*", "*/benches/*", "**/target/**"]

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -12,6 +12,8 @@ nucleo-matcher = { workspace = true }
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 tempfile = { workspace = true }
+serial_test = { workspace = true }
+temp-env = "0.3.6"
 
 [package]
 name = "org-core"


### PR DESCRIPTION
## Summary

Fixes flaky test failures in `org-core/src/config.rs` by replacing unsafe environment variable manipulation with proper test isolation.

## Changes

- **Test isolation**: Replaced `unsafe` env var operations with `temp-env::with_vars()` for automatic cleanup
- **Serial execution**: Added `#[serial]` attribute to env-dependent tests to prevent race conditions
- **Dependencies**: Added `serial_test` and `temp-env` as dev dependencies

## Test plan

- [x] All config tests pass consistently
- [x] No unsafe env var manipulation remains
- [x] Tests properly isolated and don't interfere with each other
- [x] CI builds and tests successfully