### PR TITLE
test: use env!('CARGO_PKG_VERSION') in version test

### DIFF
--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -345,7 +345,7 @@ fn test_version_command() {
     cmd.arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("0.1.0"));
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace hardcoded version string "0.1.0" with `env!("CARGO_PKG_VERSION")` in the version command integration test
- Ensures test automatically stays in sync with version changes in Cargo.toml

## Test plan
- [x] Existing test passes with the change
- [x] Test will automatically use correct version after future version bumps