### PR TITLE
chore: add crate metadata for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "org-cli"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "org-core"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "dirs",
  "nucleo-matcher",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "org-mcp-server"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "clap",
  "org-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"
 repository = "https://github.com/szaffarano/org-mcp-server"
+documentation = "https://github.com/szaffarano/org-mcp-server"
 readme = "README.org"
 
 

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -19,3 +19,5 @@ authors.workspace = true
 license.workspace = true
 version.workspace = true
 readme.workspace = true
+documentation.workspace = true
+repository.workspace = true

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -23,3 +23,5 @@ authors.workspace = true
 license.workspace = true
 version.workspace = true
 readme.workspace = true
+documentation.workspace = true
+repository.workspace = true

--- a/org-mcp-server/Cargo.toml
+++ b/org-mcp-server/Cargo.toml
@@ -44,3 +44,5 @@ authors.workspace = true
 license.workspace = true
 version.workspace = true
 readme.workspace = true
+documentation.workspace = true
+repository.workspace = true


### PR DESCRIPTION
## Summary

Add documentation and repository fields to all crate manifests to meet crates.io publishing requirements.

## Changes

- Add `documentation` field to workspace Cargo.toml
- Add `documentation` and `repository` workspace fields to all crate manifests:
  - org-cli/Cargo.toml
  - org-core/Cargo.toml
  - org-mcp-server/Cargo.toml