### PR TITLE
chore(deps): update flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1760038930,
+        "narHash": "sha256-Oncbh0UmHjSlxO7ErQDM3KM0A5/Znfofj2BSzlHLeVw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "0b4defa2584313f3b781240b29d61f6f9f7e0df3",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759718104,
-        "narHash": "sha256-TbkLsgdnXHUXR4gOQBmhxkEE9ne+eHmX1chZHWRogy0=",
+        "lastModified": 1760236527,
+        "narHash": "sha256-h9+WEQtUIZaZMvA1pnbZbMM+5X39OFnW92Q8hNoToD0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "edea9f33f9a03f615ad3609a40fbcefe0ec835ca",
+        "rev": "a38dd7f462825c75ce8567816ae38c2e7d826bfa",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1758728421,
-        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
+        "lastModified": 1760120816,
+        "narHash": "sha256-gq9rdocpmRZCwLS5vsHozwB6b5nrOBDNc2kkEaTXHfg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
+        "rev": "761ae7aff00907b607125b2f57338b74177697ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7df7ff7d8e00218376575f0acdcc5d66741351ee?narHash=sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs%3D' (2025-10-02)
  → 'github:nixos/nixpkgs/0b4defa2584313f3b781240b29d61f6f9f7e0df3?narHash=sha256-Oncbh0UmHjSlxO7ErQDM3KM0A5/Znfofj2BSzlHLeVw%3D' (2025-10-09)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/edea9f33f9a03f615ad3609a40fbcefe0ec835ca?narHash=sha256-TbkLsgdnXHUXR4gOQBmhxkEE9ne%2BeHmX1chZHWRogy0%3D' (2025-10-06)
  → 'github:oxalica/rust-overlay/a38dd7f462825c75ce8567816ae38c2e7d826bfa?narHash=sha256-h9%2BWEQtUIZaZMvA1pnbZbMM%2B5X39OFnW92Q8hNoToD0%3D' (2025-10-12)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
  → 'github:numtide/treefmt-nix/761ae7aff00907b607125b2f57338b74177697ed?narHash=sha256-gq9rdocpmRZCwLS5vsHozwB6b5nrOBDNc2kkEaTXHfg%3D' (2025-10-10)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `flake.lock` inputs for `nixpkgs`, `rust-overlay`, and `treefmt-nix` to newer commits.
> 
> - **Dependencies**:
>   - Update `flake.lock` pins:
>     - `nixpkgs_2` → newer `rev` and `narHash`.
>     - `rust-overlay` → newer `rev` and `narHash`.
>     - `treefmt-nix` → newer `rev` and `narHash`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1227fb3624bbd993ac1d3be7e1f886ef045315e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->