### PR TITLE
chore: release v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "org-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "org-core"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "chrono",
  "config",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "org-mcp-server"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "chrono",
  "clap",
@@ -1759,7 +1759,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "chrono",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"

--- a/org-cli/CHANGELOG.md
+++ b/org-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.6...org-cli-v0.0.7)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
+
+
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.5...org-cli-v0.0.6)
 
 ### ⚙️ Miscellaneous Tasks

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-org-core = { version = "0.0.6", path = "../org-core" }
+org-core = { version = "0.0.7", path = "../org-core" }
 clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/org-core/CHANGELOG.md
+++ b/org-core/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.6...org-core-v0.0.7)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
+
+### ⬆️ Dependency updates
+
+
+- *(deps)* Update rust crate tracing-subscriber to v0.3.23 ([#160](https://github.com/szaffarano/org-mcp-server/pull/160)) - ([ad65a54](https://github.com/szaffarano/org-mcp-server/commit/ad65a54c0dc6cd4af4280f8c0572b2ec09717d90))
+
+
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.5...org-core-v0.0.6)
 
 ### 🐛 Bug Fixes

--- a/org-mcp-server/CHANGELOG.md
+++ b/org-mcp-server/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.6...org-mcp-server-v0.0.7)
+
+### 🐛 Bug Fixes
+
+
+- *(deps)* Update rust crate rmcp to 0.17.0 ([#150](https://github.com/szaffarano/org-mcp-server/pull/150)) - ([e19031c](https://github.com/szaffarano/org-mcp-server/commit/e19031c28a309b8bf01835797323a28d607a5a56))
+- *(deps)* Update rust crate rmcp to 0.15.0 ([#138](https://github.com/szaffarano/org-mcp-server/pull/138)) - ([984fa36](https://github.com/szaffarano/org-mcp-server/commit/984fa36441824710081dcbf1f3f81c2e7d1176be))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
+
+
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.5...org-mcp-server-v0.0.6)
 
 ### 🐛 Bug Fixes

--- a/org-mcp-server/Cargo.toml
+++ b/org-mcp-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "org-mcp-server"
 path = "src/main.rs"
 
 [dependencies]
-org-core = { version = "0.0.6", path = "../org-core" }
+org-core = { version = "0.0.7", path = "../org-core" }
 rmcp = { version = "0.17.0", features = [
   "transport-io",
   "transport-child-process",


### PR DESCRIPTION



## 🤖 New release

* `org-core`: 0.0.6 -> 0.0.7 (✓ API compatible changes)
* `org-mcp-server`: 0.0.6 -> 0.0.7 (✓ API compatible changes)
* `org-cli`: 0.0.6 -> 0.0.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `org-core`

<blockquote>

## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.6...org-core-v0.0.7)

### ⚙️ Miscellaneous Tasks


- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))

### ⬆️ Dependency updates


- *(deps)* Update rust crate tracing-subscriber to v0.3.23 ([#160](https://github.com/szaffarano/org-mcp-server/pull/160)) - ([ad65a54](https://github.com/szaffarano/org-mcp-server/commit/ad65a54c0dc6cd4af4280f8c0572b2ec09717d90))
</blockquote>

## `org-mcp-server`

<blockquote>

## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.6...org-mcp-server-v0.0.7)

### 🐛 Bug Fixes


- *(deps)* Update rust crate rmcp to 0.17.0 ([#150](https://github.com/szaffarano/org-mcp-server/pull/150)) - ([e19031c](https://github.com/szaffarano/org-mcp-server/commit/e19031c28a309b8bf01835797323a28d607a5a56))
- *(deps)* Update rust crate rmcp to 0.15.0 ([#138](https://github.com/szaffarano/org-mcp-server/pull/138)) - ([984fa36](https://github.com/szaffarano/org-mcp-server/commit/984fa36441824710081dcbf1f3f81c2e7d1176be))

### ⚙️ Miscellaneous Tasks


- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
</blockquote>

## `org-cli`

<blockquote>

## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.6...org-cli-v0.0.7)

### ⚙️ Miscellaneous Tasks


- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: bumps crate/workspace versions and updates changelogs and intra-workspace dependency pins, with no functional code changes in this diff.
> 
> **Overview**
> Prepares the `v0.0.7` release by bumping the workspace and crate versions (`org-core`, `org-mcp-server`, `org-cli`, `test-utils`) from `0.0.6` to `0.0.7` and updating `Cargo.lock` accordingly.
> 
> Updates `org-cli`/`org-mcp-server` to depend on `org-core` `0.0.7`, and adds `0.0.7` entries to the respective `CHANGELOG.md` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a1d4b9201ae29a196b24f1ca3a260cf4a2d2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->