### PR TITLE
fix: Update nix pkg build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,9 @@
 
             src = pkgs.lib.cleanSource ./.;
             cargoLock = {
+              outputHashes = {
+                "orgize-0.10.0-alpha.10" = "sha256-UDH1uwdp9/1jJugOzpLeyhecJpg+uY8maUe3c+WsDCs=";
+              };
               lockFile = ./Cargo.lock;
             };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Nix packaging change that only affects build reproducibility; no runtime or application logic changes.
> 
> **Overview**
> Fixes the Nix flake build for the Rust package by adding a `cargoLock.outputHashes` entry for the `orgize-0.10.0-alpha.10` dependency, enabling `buildRustPackage` to fetch/build that crate reproducibly under fixed-output hashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b8dc2964b2b1c891929c2874c5ff1a37942f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->