### PR TITLE
Some fixes to flake and agenda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .direnv
+.idea/
 .pre-commit-config.yaml
 
 # Coverage reports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -1555,9 +1555,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["org-mcp-server", "org-cli", "org-core", "test-utils"]
 
 [workspace.dependencies]
 anyhow = "1.0"
-assert_cmd = "2.0"
+assert_cmd = "2.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 config = "0.15"
@@ -29,8 +29,8 @@ orgize = { git = "https://github.com/szaffarano/orgize/", rev = "c4b38cb59131b47
 ] }
 paste = "1.0"
 predicates = "3.1"
-regex = "1.11"
-rmcp = { version = "0.15.0", features = [
+regex = "1.12"
+rmcp = { version = "1.1.0", features = [
   "transport-io",
   "transport-child-process",
   "transport-streamable-http-server",
@@ -38,11 +38,11 @@ rmcp = { version = "0.15.0", features = [
   "client",
 ] }
 rowan = "0.16"
-serde_json = "1.0.145"
+serde_json = "1.0.149"
 serde = { version = "1.0", features = ["derive"] }
-serial_test = "3.2.0"
-shellexpand = "3.1.1"
-tempfile = "3.23"
+serial_test = "3.4.0"
+shellexpand = "3.1.2"
+tempfile = "3.26"
 temp-env = "0.3.6"
 tokio-test = "0.4"
 tokio = { version = "1", features = [
@@ -54,14 +54,14 @@ tokio = { version = "1", features = [
   "signal",
 ] }
 toml = "1.0"
-tracing = "0.1.41"
-tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.20", features = [
+tracing = "0.1.44"
+tracing-appender = "0.2.4"
+tracing-subscriber = { version = "0.3.22", features = [
   "env-filter",
   "std",
   "fmt",
 ] }
-tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
+tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 urlencoding = "2.1"
 
 [workspace.metadata.coverage]

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
         packages = {
           default = self'.packages.org-mcp;
           org-mcp = pkgsWithOverlay.rustPlatform.buildRustPackage rec {
-            pname = "org-mcp";
+            pname = "org-mcp-server";
             version = let
               cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
             in

--- a/org-cli/src/commands/agenda.rs
+++ b/org-cli/src/commands/agenda.rs
@@ -171,6 +171,7 @@ impl AgendaCommand {
                     AgendaViewType::Today,
                     None,
                     tags.as_ref().map(|v| v.as_slice()),
+                    self.limit,
                 )?;
 
                 self.print_agenda_view(view, format, &org_mode)?;
@@ -181,6 +182,7 @@ impl AgendaCommand {
                     AgendaViewType::CurrentWeek,
                     None,
                     tags.as_ref().map(|v| v.as_slice()),
+                    self.limit,
                 )?;
 
                 self.print_agenda_view(view, format, &org_mode)?;
@@ -211,6 +213,7 @@ impl AgendaCommand {
                     AgendaViewType::Custom { from, to },
                     None,
                     tags.as_ref().map(|v| v.as_slice()),
+                    self.limit,
                 )?;
 
                 self.print_agenda_view(view, format, &org_mode)?;

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -461,6 +461,7 @@ fn test_config_show_displays_config() {
 fn test_config_show_fallback_to_default() {
     cargo::cargo_bin_cmd!("org-cli")
         .env("XDG_CONFIG_HOME", "/nonexistent/path")
+        .env("HOME", "/nonexistent/home")
         .arg("config")
         .arg("show")
         .assert()

--- a/org-core/src/config.rs
+++ b/org-core/src/config.rs
@@ -267,7 +267,7 @@ pub fn default_notes_file() -> String {
 }
 
 pub fn default_agenda_files() -> Vec<String> {
-    vec!["agenda.org".to_string()]
+    vec!["**/*.org".to_string()]
 }
 
 pub fn default_todo_keywords() -> Vec<String> {
@@ -294,7 +294,7 @@ mod tests {
         let config = OrgConfig::default();
         assert_eq!(config.org_directory, "~/org/");
         assert_eq!(config.org_default_notes_file, "notes.org");
-        assert_eq!(config.org_agenda_files, vec!["agenda.org"]);
+        assert_eq!(config.org_agenda_files, vec!["**/*.org"]);
         assert!(config.org_agenda_text_search_extra_files.is_empty());
     }
 

--- a/org-core/src/org_mode.rs
+++ b/org-core/src/org_mode.rs
@@ -485,6 +485,12 @@ impl OrgMode {
             org_root.join(&path).to_str().unwrap_or(&path).to_string()
         };
 
+        let path = if PathBuf::from(&path).is_dir() {
+            format!("{}/**/*.org", path.trim_end_matches('/'))
+        } else {
+            path
+        };
+
         let root = path
             .split_once('*')
             .map(|(prefix, _)| prefix)
@@ -614,8 +620,9 @@ impl OrgMode {
         agenda_view_type: AgendaViewType,
         todo_states: Option<&[String]>,
         tags: Option<&[String]>,
+        limit: Option<usize>,
     ) -> Result<AgendaView, OrgModeError> {
-        let items = self
+        let mut items = self
             .agenda_tasks()
             .filter(|(headline, _)| {
                 tags.map(|tags| {
@@ -637,6 +644,10 @@ impl OrgMode {
             })
             .map(|(headline, file_path)| Self::headline_to_agenda_item(&headline, file_path))
             .collect::<Vec<_>>();
+
+        if let Some(limit) = limit {
+            items.truncate(limit);
+        }
 
         Ok(AgendaView {
             items,
@@ -666,7 +677,18 @@ impl OrgMode {
             // more info https://orgmode.org/org.html#Repeated-tasks
             if let Some(ts) = ts_opt
                 && let Some(date) = OrgMode::start_to_chrono(&ts)
-                && let Some(date) = Local.from_local_datetime(&date).single()
+                && let Some(date) = match Local.from_local_datetime(&date) {
+                    chrono::LocalResult::Single(t) => Some(t),
+                    chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                    chrono::LocalResult::None => {
+                        let dt_plus_1 = date + chrono::Duration::hours(1);
+                        match Local.from_local_datetime(&dt_plus_1) {
+                            chrono::LocalResult::Single(t) => Some(t),
+                            chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                            chrono::LocalResult::None => None,
+                        }
+                    }
+                }
             {
                 if let Some(repeater_value) = ts.repeater_value()
                     && let Some(repeater_unit) = ts.repeater_unit()
@@ -709,7 +731,18 @@ impl OrgMode {
     fn to_start_of_day(date: DateTime<Local>) -> DateTime<Local> {
         date.date_naive()
             .and_hms_opt(0, 0, 0)
-            .and_then(|dt| Local.from_local_datetime(&dt).single())
+            .and_then(|dt| match Local.from_local_datetime(&dt) {
+                chrono::LocalResult::Single(t) => Some(t),
+                chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                chrono::LocalResult::None => {
+                    let dt_plus_1 = dt + chrono::Duration::hours(1);
+                    match Local.from_local_datetime(&dt_plus_1) {
+                        chrono::LocalResult::Single(t) => Some(t),
+                        chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                        chrono::LocalResult::None => None,
+                    }
+                }
+            })
             .unwrap_or(date)
     }
 
@@ -717,7 +750,18 @@ impl OrgMode {
     fn to_end_of_day(date: DateTime<Local>) -> DateTime<Local> {
         date.date_naive()
             .and_hms_opt(23, 59, 59)
-            .and_then(|dt| Local.from_local_datetime(&dt).single())
+            .and_then(|dt| match Local.from_local_datetime(&dt) {
+                chrono::LocalResult::Single(t) => Some(t),
+                chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                chrono::LocalResult::None => {
+                    let dt_minus_1 = dt - chrono::Duration::hours(1);
+                    match Local.from_local_datetime(&dt_minus_1) {
+                        chrono::LocalResult::Single(t) => Some(t),
+                        chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                        chrono::LocalResult::None => None,
+                    }
+                }
+            })
             .unwrap_or(date)
     }
 
@@ -729,7 +773,18 @@ impl OrgMode {
         sec: u32,
     ) -> Result<DateTime<Local>, OrgModeError> {
         date.and_hms_opt(hour, min, sec)
-            .and_then(|dt| Local.from_local_datetime(&dt).single())
+            .and_then(|dt| match Local.from_local_datetime(&dt) {
+                chrono::LocalResult::Single(t) => Some(t),
+                chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                chrono::LocalResult::None => {
+                    let dt_plus_1 = dt + chrono::Duration::hours(1);
+                    match Local.from_local_datetime(&dt_plus_1) {
+                        chrono::LocalResult::Single(t) => Some(t),
+                        chrono::LocalResult::Ambiguous(t, _) => Some(t),
+                        chrono::LocalResult::None => None,
+                    }
+                }
+            })
             .ok_or_else(|| {
                 OrgModeError::InvalidAgendaViewType(format!(
                     "Could not convert date '{}' to local timezone",

--- a/org-core/tests/agenda_tests.rs
+++ b/org-core/tests/agenda_tests.rs
@@ -864,7 +864,7 @@ fn test_list_tasks_no_match_filters() {
 fn test_get_agenda_view_today() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Today, None, None)
+        .get_agenda_view(AgendaViewType::Today, None, None, None)
         .expect("Failed to get today's agenda view");
 
     assert!(
@@ -901,7 +901,7 @@ fn test_get_agenda_view_today() {
 fn test_get_agenda_view_current_week() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::CurrentWeek, None, None)
+        .get_agenda_view(AgendaViewType::CurrentWeek, None, None, None)
         .expect("Failed to get current week agenda view");
 
     assert!(
@@ -935,7 +935,7 @@ fn test_get_agenda_view_current_week() {
 fn test_get_agenda_view_custom_week() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Week(9), None, None)
+        .get_agenda_view(AgendaViewType::Week(9), None, None, None)
         .expect("Failed to get current week agenda view");
 
     assert!(
@@ -957,7 +957,7 @@ fn test_get_agenda_view_custom_range() {
     let to = today.checked_add_days(Days::new(6)).unwrap();
 
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Custom { from, to }, None, None)
+        .get_agenda_view(AgendaViewType::Custom { from, to }, None, None, None)
         .expect("Failed to get custom range agenda view");
 
     assert!(
@@ -995,6 +995,7 @@ fn test_get_agenda_view_with_filters() {
             AgendaViewType::Today,
             Some(&["TODO".to_string()]),
             Some(&["work".to_string()]),
+            None,
         )
         .expect("Failed to get filtered agenda view");
 
@@ -1009,7 +1010,7 @@ fn test_get_agenda_view_empty_results() {
     let to = Local.with_ymd_and_hms(2030, 1, 7, 23, 59, 59).unwrap();
 
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Custom { from, to }, None, None)
+        .get_agenda_view(AgendaViewType::Custom { from, to }, None, None, None)
         .expect("Failed to get agenda view");
 
     // Far future dates should have no tasks
@@ -1024,7 +1025,7 @@ fn test_get_agenda_view_empty_results() {
 fn test_agenda_today_finds_scheduled_tasks() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Today, None, None)
+        .get_agenda_view(AgendaViewType::Today, None, None, None)
         .expect("Failed to get today's agenda");
 
     // Verify tasks scheduled for @TODAY@ are found
@@ -1049,7 +1050,7 @@ fn test_agenda_today_finds_scheduled_tasks() {
 fn test_agenda_today_excludes_future_tasks() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::Today, None, None)
+        .get_agenda_view(AgendaViewType::Today, None, None, None)
         .expect("Failed to get today's agenda");
 
     // Tasks scheduled for @TODAY+1@ or later should not be in today's view
@@ -1068,7 +1069,7 @@ fn test_agenda_today_excludes_future_tasks() {
 fn test_agenda_week_includes_all_week_tasks() {
     let (org_mode, _temp_dir) = create_test_org_mode_with_agenda_files();
     let view = org_mode
-        .get_agenda_view(AgendaViewType::CurrentWeek, None, None)
+        .get_agenda_view(AgendaViewType::CurrentWeek, None, None, None)
         .expect("Failed to get current week agenda");
 
     // Week should include tasks from the current week (Monday through Sunday)

--- a/org-mcp-server/src/lib.rs
+++ b/org-mcp-server/src/lib.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod core;
 pub(crate) mod resources;
 pub(crate) mod tools;
+pub(crate) mod utils;

--- a/org-mcp-server/src/resources/org_agenda.rs
+++ b/org-mcp-server/src/resources/org_agenda.rs
@@ -15,7 +15,7 @@ impl OrgModeRouter {
         let org_mode = self.org_mode.lock().await;
 
         let result = org_mode
-            .get_agenda_view(agenda_view_type, None, None)
+            .get_agenda_view(agenda_view_type, None, None, None)
             .map(|tasks| json!(tasks).to_string());
 
         match result {

--- a/org-mcp-server/src/tools/org_agenda.rs
+++ b/org-mcp-server/src/tools/org_agenda.rs
@@ -28,6 +28,10 @@ pub struct AgendaRequest {
     #[schemars(description = "Filter by priority level (optional: A, B, or C)")]
     pub priority: Option<String>,
     #[schemars(description = "Maximum number of items to return (optional)")]
+    #[serde(
+        default,
+        deserialize_with = "crate::utils::deserialize_string_or_number"
+    )]
     pub limit: Option<usize>,
     #[schemars(
         description = "View mode: 'list' for all tasks, 'view' for date-organized agenda (default: 'list')"
@@ -39,7 +43,7 @@ pub struct AgendaRequest {
 impl OrgModeRouter {
     #[tool(
         name = "org-agenda",
-        description = "Query agenda items (TODO/DONE tasks) with support for filtering by dates, states, tags, and priorities. Use 'list' mode to get all tasks, or 'view' mode for calendar-like agenda organized by scheduled/deadline dates.",
+        description = "Query agenda items (TODO/DONE tasks) with support for filtering by dates, states, tags, and priorities. You can also specify a limit to the number of results returned to save context window space. Use 'list' mode to get all tasks, or 'view' mode for calendar-like agenda organized by scheduled/deadline dates.",
         annotations(title = "org-agenda tool")
     )]
     async fn tool_agenda(
@@ -133,6 +137,7 @@ impl OrgModeRouter {
                     agenda_view_type,
                     todo_states.as_deref(),
                     tags.as_deref(),
+                    limit,
                 );
 
                 match view {

--- a/org-mcp-server/src/tools/org_file_list.rs
+++ b/org-mcp-server/src/tools/org_file_list.rs
@@ -13,6 +13,10 @@ pub struct ListFilesRequest {
     #[schemars(description = "Filter results by tags (optional)")]
     pub tags: Option<Vec<String>>,
     #[schemars(description = "Maximum number of files to return (optional)")]
+    #[serde(
+        default,
+        deserialize_with = "crate::utils::deserialize_string_or_number"
+    )]
     pub limit: Option<usize>,
 }
 
@@ -20,7 +24,7 @@ pub struct ListFilesRequest {
 impl OrgModeRouter {
     #[tool(
         name = "org-file-list",
-        description = "List all the org files defined in the org-mode configuration",
+        description = "List all the org files defined in the org-mode configuration. You can optionally use the 'limit' parameter to control how many files are returned.",
         annotations(title = "org-file-list tool")
     )]
     async fn tool_list_files(

--- a/org-mcp-server/src/tools/org_search.rs
+++ b/org-mcp-server/src/tools/org_search.rs
@@ -13,8 +13,16 @@ pub struct SearchRequest {
     #[schemars(description = "Search query string to find in org file content")]
     pub query: String,
     #[schemars(description = "Maximum number of search results to return (optional)")]
+    #[serde(
+        default,
+        deserialize_with = "crate::utils::deserialize_string_or_number"
+    )]
     pub limit: Option<usize>,
     #[schemars(description = "Maximum snippet size in characters (optional, default: 100)")]
+    #[serde(
+        default,
+        deserialize_with = "crate::utils::deserialize_string_or_number"
+    )]
     pub snippet_max_size: Option<usize>,
     #[schemars(
         description = "Filter results by tags (optional, matches any of the provided tags)"
@@ -26,7 +34,7 @@ pub struct SearchRequest {
 impl OrgModeRouter {
     #[tool(
         name = "org-search",
-        description = "Search for text content across all org files using fuzzy matching",
+        description = "Search for text content across all org files using fuzzy matching. You can optionally specify a limit to the number of results returned.",
         annotations(title = "org-search tool")
     )]
     async fn tool_search(

--- a/org-mcp-server/src/utils.rs
+++ b/org-mcp-server/src/utils.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Deserializer};
+
+pub(crate) fn deserialize_string_or_number<'de, D>(
+    deserializer: D,
+) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrNumber {
+        String(String),
+        Number(usize),
+    }
+
+    match Option::<StringOrNumber>::deserialize(deserializer)? {
+        Some(StringOrNumber::String(s)) => {
+            if s.is_empty() {
+                Ok(None)
+            } else {
+                s.parse().map(Some).map_err(serde::de::Error::custom)
+            }
+        }
+        Some(StringOrNumber::Number(n)) => Ok(Some(n)),
+        None => Ok(None),
+    }
+}

--- a/org-mcp-server/tests/integration_tests/tools_tests.rs
+++ b/org-mcp-server/tests/integration_tests/tools_tests.rs
@@ -981,3 +981,93 @@ async fn test_org_agenda_tool_all_parameters() -> Result<(), Box<dyn std::error:
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_org_agenda_tool_view_mode_with_limit() -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting MCP client to test org-agenda tool view mode with limit");
+
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let mut args = Map::new();
+    args.insert("mode".to_string(), Value::String("view".into()));
+    args.insert("limit".to_string(), Value::Number(1.into()));
+
+    let result = service
+        .call_tool(CallToolRequestParams {
+            name: "org-agenda".into(),
+            arguments: Some(args),
+            meta: None,
+            task: None,
+        })
+        .await?;
+
+    info!("org-agenda view with limit result: {:#?}", result);
+    assert!(!result.content.is_empty());
+
+    if let Some(content) = result.content.first() {
+        if let Some(text) = content.as_text() {
+            let view: serde_json::Value =
+                serde_json::from_str(&text.text).expect("View should be valid JSON");
+
+            let items = view["items"].as_array().expect("Should have items array");
+            assert!(
+                items.len() <= 1,
+                "Should respect limit parameter, got {}",
+                items.len()
+            );
+        } else {
+            panic!("Expected text content in org-agenda result");
+        }
+    } else {
+        panic!("No content in org-agenda result");
+    }
+
+    service.cancel().await?;
+    info!("org-agenda view mode with limit test completed successfully");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_org_agenda_tool_limit_as_string() -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting MCP client to test org-agenda tool with string limit");
+
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let mut args = Map::new();
+    args.insert("mode".to_string(), Value::String("list".into()));
+    args.insert("limit".to_string(), Value::String("2".into())); // Provided as string
+
+    let result = service
+        .call_tool(CallToolRequestParams {
+            name: "org-agenda".into(),
+            arguments: Some(args),
+            meta: None,
+            task: None,
+        })
+        .await?;
+
+    info!("org-agenda string limit result: {:#?}", result);
+    assert!(!result.content.is_empty());
+
+    if let Some(content) = result.content.first() {
+        if let Some(text) = content.as_text() {
+            let tasks: serde_json::Value =
+                serde_json::from_str(&text.text).expect("Tasks should be valid JSON");
+
+            if let Some(tasks_array) = tasks.as_array() {
+                assert!(
+                    tasks_array.len() <= 2,
+                    "Should respect string limit parameter"
+                );
+            }
+        } else {
+            panic!("Expected text content");
+        }
+    }
+
+    service.cancel().await?;
+    Ok(())
+}


### PR DESCRIPTION
- flake was wrong and I could start `nix run ...` because there should be `pname = "org-mcp-server"`
- my tests failed because I have `~/org` directory nonempty and tests used that, so it's changed to some random directory
- my agenda was empty, caused by bad glob on dir
- bumped up cargo deps
- fixed chrono timestamp parsing as reported by llm