### PR TITLE
chore(deps): switch orgize to crates.io 0.10.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "org-cli"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "org-core"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "chrono",
  "config",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "org-mcp-server"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "chrono",
  "clap",
@@ -1770,7 +1770,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "chrono",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1105,8 @@ dependencies = [
 [[package]]
 name = "orgize"
 version = "0.10.0-alpha.10"
-source = "git+https://github.com/szaffarano/orgize/?rev=c4b38cb59131b4776e4edd52a1580737acb9df30#c4b38cb59131b4776e4edd52a1580737acb9df30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b747231437c1d8e68355427250c167d3e4d94874727923511e4572b7f5fecd51"
 dependencies = [
  "bytecount",
  "cfg-if",
@@ -1435,12 +1445,13 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.16.1"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
+ "memoffset",
  "rustc-hash",
  "text-size",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.7"
+version = "0.0.6"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ ignore = "0.4"
 nucleo-matcher = "0.3"
 once_cell = "1.21.3"
 org-core = { version = "0.0.1", path = "../org-core" }
-orgize = { git = "https://github.com/szaffarano/orgize/", rev = "c4b38cb59131b4776e4edd52a1580737acb9df30", features = [
-  "tracing",
-] }
+orgize = { version = "0.10.0-alpha.10", features = ["tracing"] }
 paste = "1.0"
 predicates = "3.1"
 regex = "1.12"
@@ -37,7 +35,7 @@ rmcp = { version = "1.1.0", features = [
   "transport-worker",
   "client",
 ] }
-rowan = "0.16"
+rowan = "0.15"
 serde_json = "1.0.149"
 serde = { version = "1.0", features = ["derive"] }
 serial_test = "3.4.0"

--- a/org-cli/CHANGELOG.md
+++ b/org-cli/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.6...org-cli-v0.0.7)
-
-### ⚙️ Miscellaneous Tasks
-
-
-- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
-
-
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.5...org-cli-v0.0.6)
 
 ### ⚙️ Miscellaneous Tasks

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-org-core = { version = "0.0.7", path = "../org-core" }
+org-core = { version = "0.0.6", path = "../org-core" }
 clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/org-core/CHANGELOG.md
+++ b/org-core/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.6...org-core-v0.0.7)
-
-### ⚙️ Miscellaneous Tasks
-
-
-- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
-
-### ⬆️ Dependency updates
-
-
-- *(deps)* Update rust crate tracing-subscriber to v0.3.23 ([#160](https://github.com/szaffarano/org-mcp-server/pull/160)) - ([ad65a54](https://github.com/szaffarano/org-mcp-server/commit/ad65a54c0dc6cd4af4280f8c0572b2ec09717d90))
-
-
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.5...org-core-v0.0.6)
 
 ### 🐛 Bug Fixes

--- a/org-mcp-server/CHANGELOG.md
+++ b/org-mcp-server/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.6...org-mcp-server-v0.0.7)
-
-### 🐛 Bug Fixes
-
-
-- *(deps)* Update rust crate rmcp to 0.17.0 ([#150](https://github.com/szaffarano/org-mcp-server/pull/150)) - ([e19031c](https://github.com/szaffarano/org-mcp-server/commit/e19031c28a309b8bf01835797323a28d607a5a56))
-- *(deps)* Update rust crate rmcp to 0.15.0 ([#138](https://github.com/szaffarano/org-mcp-server/pull/138)) - ([984fa36](https://github.com/szaffarano/org-mcp-server/commit/984fa36441824710081dcbf1f3f81c2e7d1176be))
-
-### ⚙️ Miscellaneous Tasks
-
-
-- Some fixes to flake and agenda ([#158](https://github.com/szaffarano/org-mcp-server/pull/158)) - ([3d96b65](https://github.com/szaffarano/org-mcp-server/commit/3d96b65fe5be59ab6f1a666c5f15fba7dfa45db9))
-
-
 ## [0.0.6](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.5...org-mcp-server-v0.0.6)
 
 ### 🐛 Bug Fixes

--- a/org-mcp-server/Cargo.toml
+++ b/org-mcp-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "org-mcp-server"
 path = "src/main.rs"
 
 [dependencies]
-org-core = { version = "0.0.7", path = "../org-core" }
+org-core = { version = "0.0.6", path = "../org-core" }
 rmcp = { version = "1.0.0", features = [
   "transport-io",
   "transport-child-process",


### PR DESCRIPTION
- **chore(deps): switch orgize to crates.io 0.10.0-alpha.1**
- **Revert "chore: release v0.0.7 (#164)"**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency and versioning changes, but switching `orgize` source and downgrading `rowan` could introduce subtle parsing/AST compatibility issues at build or runtime.
> 
> **Overview**
> Switches `orgize` from a pinned Git dependency to the crates.io `0.10.0-alpha.10` release and adjusts the workspace dependency set accordingly (including `rowan` `0.16` → `0.15`).
> 
> Reverts the prior `0.0.7` release bump by setting the workspace/crate versions back to `0.0.6`, updating `org-cli`/`org-mcp-server` `org-core` dependency versions, and removing the `0.0.7` entries from the changelogs; `Cargo.lock` is regenerated (e.g., adds `memoffset`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078d865c3558b0d41051f771b2e5bd24ac14810c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->