### PR TITLE
chore(deps): Pin rowan to v0.15

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "nix": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["rowan"],
+      "allowedVersions": "0.15"
+    }
+  ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes Renovate configuration to constrain dependency updates, with no runtime or application logic impact.
> 
> **Overview**
> Pins Rust crate updates for `rowan` by adding a Renovate `packageRules` entry that restricts Cargo to `allowedVersions: "0.15"`, preventing automated upgrades beyond that major/minor line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b55af968dc46767005c9a695d31fd7164cc7156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->