### PR TITLE
chore: migrate from unmaintained paste crate to pastey

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,22 @@
+name: Security audit
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Scan for vulnerabilities
+        run: cargo deny check advisories

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@cargo-deny
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
       - name: Scan for vulnerabilities
         run: cargo deny check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,63 @@ name: CI
 on:
   pull_request:
     branches: [master]
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
+      - "**/*.rs"
   push:
     branches: [master]
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
+      - "**/*.rs"
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Enforce formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Linting
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -20,7 +72,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -31,36 +82,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Build
-        run: cargo build --verbose --all-targets
+        run: cargo build --verbose --all-targets --all-features
       - name: Run tests
-        run: |
-          cargo build
-          cargo test --verbose --all-targets
-  check:
-    name: Check
+        run: cargo test --verbose --all-targets --all-features
+
+  machete:
+    name: Detect unused dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ubuntu-latest-cargo-
-      - name: Check Cargo.toml formatting
-        run: cargo fmt --all -- --check
-      - name: Run cargo check
-        run: cargo check --all-targets --all-features
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Machete
+        uses: bnjbvr/cargo-machete@v0.9.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -1063,7 +1063,7 @@ dependencies = [
  "ignore",
  "nucleo-matcher",
  "orgize",
- "paste",
+ "pastey",
  "regex",
  "rowan",
  "serde",
@@ -1140,12 +1140,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "shellexpand",
  "temp-env",
  "tempfile",
  "test-utils",
@@ -1074,7 +1073,6 @@ dependencies = [
  "tempfile",
  "test-utils",
  "toml",
- "tracing",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ nucleo-matcher = "0.3"
 once_cell = "1.21.3"
 org-core = { version = "0.0.1", path = "../org-core" }
 orgize = { version = "0.10.0-alpha.10", features = ["tracing"] }
-paste = "1.0"
+pastey = "0.2"
 predicates = "3.1"
 regex = "1.12"
 rmcp = { version = "1.1.0", features = [

--- a/flake.lock
+++ b/flake.lock
@@ -38,7 +38,9 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1776796298,
@@ -77,16 +79,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
-        "owner": "NixOS",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -106,43 +108,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1770107345,
-        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       }
@@ -169,7 +139,9 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1775636079,

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,6 @@
 {
+  description = "OrgMode MCP Server";
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
@@ -6,8 +8,14 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    git-hooks-nix.url = "github:cachix/git-hooks.nix";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
+    git-hooks-nix = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {
@@ -128,8 +136,10 @@
             inherit (self'.checks) pre-commit;
             packages = with pkgsWithOverlay; [
               cargo-bloat
+              cargo-deny
               cargo-edit
               cargo-llvm-cov
+              cargo-machete
               cargo-nextest
               cargo-outdated
               cargo-semver-checks

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -6,7 +6,6 @@ chrono = { workspace = true }
 config = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-shellexpand = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -6,7 +6,7 @@ globset.workspace = true
 ignore.workspace = true
 nucleo-matcher.workspace = true
 orgize = { workspace = true, features = ["tracing", "chrono"] }
-paste.workspace = true
+pastey.workspace = true
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 shellexpand.workspace = true

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -11,7 +11,6 @@ serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 shellexpand.workspace = true
 toml.workspace = true
-tracing.workspace = true
 rowan.workspace = true
 
 [dev-dependencies]

--- a/org-core/src/org_mode.rs
+++ b/org-core/src/org_mode.rs
@@ -24,7 +24,7 @@ use crate::utils::tags_match;
 /// the appropriate method calls (year_start/year_end, etc.).
 macro_rules! convert_timestamp {
     ($ts:expr, $prefix:ident) => {{
-        paste::paste! {
+        pastey::paste! {
             let year = $ts.[<year_ $prefix>]()?;
             let month = $ts.[<month_ $prefix>]()?;
             let day = $ts.[<day_ $prefix>]()?;


### PR DESCRIPTION
## Summary

- Migrate from the unmaintained `paste` crate to `pastey` (drop-in replacement)
- Update workspace dependency: `paste = "1.0"` → `pastey = "0.2"`
- Update macro invocation: `paste::paste!` → `pastey::paste!`
- Update flake.nix shell
- Regorganize CI pipelines



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core build/CI behavior (new jobs, all-features builds, new dependency checks) and swaps a macro dependency, which could surface new warnings or feature-gated build failures.
> 
> **Overview**
> Migrates macro concatenation from `paste` to `pastey` across the workspace (dependency swap in `Cargo.toml`/`Cargo.lock` and `pastey::paste!` in `org-core/src/org_mode.rs`), plus a small lockfile dependency bump (`bytes`).
> 
> Reworks GitHub Actions: adds a scheduled/on-change `cargo-deny` security audit workflow, splits CI into dedicated `fmt` and `clippy` jobs, runs build/tests with `--all-features`, scopes CI triggers via `paths`, and adds a `cargo-machete` job to detect unused dependencies.
> 
> Updates Nix flake wiring/pins (inputs follow `nixpkgs`, refreshed `flake.lock`) and expands the dev shell to include `cargo-deny` and `cargo-machete`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680d0f111303e3df4df018436dc84748938fc596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->