### PR TITLE
chore: release v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "org-cli"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "org-core"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "chrono",
  "config",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "org-mcp-server"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "chrono",
  "clap",
@@ -1772,7 +1772,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "chrono",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"

--- a/org-cli/CHANGELOG.md
+++ b/org-cli/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.7...org-cli-v0.0.8)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Migrate from unmaintained paste crate to pastey ([#174](https://github.com/szaffarano/org-mcp-server/pull/174)) - ([6f51563](https://github.com/szaffarano/org-mcp-server/commit/6f515636a1ed943fbfaca950ecdd56a3e09b665e))
+
+### ⬆️ Dependency updates
+
+
+- *(deps)* Update rust crate tokio to v1.53.1 ([#201](https://github.com/szaffarano/org-mcp-server/pull/201)) - ([6aa8892](https://github.com/szaffarano/org-mcp-server/commit/6aa8892a58cb6f427b6fe6bd834bc9c209bb38f3))
+
+
 ## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.6...org-cli-v0.0.7)
 
 ### ⚙️ Miscellaneous Tasks

--- a/org-cli/Cargo.toml
+++ b/org-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-org-core = { version = "0.0.7", path = "../org-core" }
+org-core = { version = "0.0.8", path = "../org-core" }
 clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/org-core/CHANGELOG.md
+++ b/org-core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.7...org-core-v0.0.8)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Migrate from unmaintained paste crate to pastey ([#174](https://github.com/szaffarano/org-mcp-server/pull/174)) - ([6f51563](https://github.com/szaffarano/org-mcp-server/commit/6f515636a1ed943fbfaca950ecdd56a3e09b665e))
+
+
 ## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.6...org-core-v0.0.7)
 
 ### ⚙️ Miscellaneous Tasks

--- a/org-mcp-server/CHANGELOG.md
+++ b/org-mcp-server/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.7...org-mcp-server-v0.0.8)
+
+### 🐛 Bug Fixes
+
+
+- *(deps)* Update rust crate rmcp to v2 ([#195](https://github.com/szaffarano/org-mcp-server/pull/195)) - ([ab73197](https://github.com/szaffarano/org-mcp-server/commit/ab7319712e0e6d3a5a3f38766f69bbf1b7a25e1b))
+
+
 ## [0.0.7](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.6...org-mcp-server-v0.0.7)
 
 ### 🐛 Bug Fixes

--- a/org-mcp-server/Cargo.toml
+++ b/org-mcp-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "org-mcp-server"
 path = "src/main.rs"
 
 [dependencies]
-org-core = { version = "0.0.7", path = "../org-core" }
+org-core = { version = "0.0.8", path = "../org-core" }
 rmcp = { version = "2.0.0", features = [
   "transport-io",
   "transport-child-process",


### PR DESCRIPTION



## 🤖 New release

* `org-core`: 0.0.7 -> 0.0.8 (✓ API compatible changes)
* `org-mcp-server`: 0.0.7 -> 0.0.8 (✓ API compatible changes)
* `org-cli`: 0.0.7 -> 0.0.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `org-core`

<blockquote>

## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-core-v0.0.7...org-core-v0.0.8)

### ⚙️ Miscellaneous Tasks


- Migrate from unmaintained paste crate to pastey ([#174](https://github.com/szaffarano/org-mcp-server/pull/174)) - ([6f51563](https://github.com/szaffarano/org-mcp-server/commit/6f515636a1ed943fbfaca950ecdd56a3e09b665e))
</blockquote>

## `org-mcp-server`

<blockquote>

## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-mcp-server-v0.0.7...org-mcp-server-v0.0.8)

### 🐛 Bug Fixes


- *(deps)* Update rust crate rmcp to v2 ([#195](https://github.com/szaffarano/org-mcp-server/pull/195)) - ([ab73197](https://github.com/szaffarano/org-mcp-server/commit/ab7319712e0e6d3a5a3f38766f69bbf1b7a25e1b))
</blockquote>

## `org-cli`

<blockquote>

## [0.0.8](https://github.com/szaffarano/org-mcp-server/compare/org-cli-v0.0.7...org-cli-v0.0.8)

### ⚙️ Miscellaneous Tasks


- Migrate from unmaintained paste crate to pastey ([#174](https://github.com/szaffarano/org-mcp-server/pull/174)) - ([6f51563](https://github.com/szaffarano/org-mcp-server/commit/6f515636a1ed943fbfaca950ecdd56a3e09b665e))

### ⬆️ Dependency updates


- *(deps)* Update rust crate tokio to v1.53.1 ([#201](https://github.com/szaffarano/org-mcp-server/pull/201)) - ([6aa8892](https://github.com/szaffarano/org-mcp-server/commit/6aa8892a58cb6f427b6fe6bd834bc9c209bb38f3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).