### PR TITLE
fix(flake): Update build config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,9 +68,6 @@
 
             src = pkgs.lib.cleanSource ./.;
             cargoLock = {
-              outputHashes = {
-                "orgize-0.10.0-alpha.10" = "sha256-UDH1uwdp9/1jJugOzpLeyhecJpg+uY8maUe3c+WsDCs=";
-              };
               lockFile = ./Cargo.lock;
             };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Nix build inputs for Rust packaging; risk is mainly that `nix build` could fail if any Cargo dependencies still require fixed-output `outputHashes`. No runtime code is changed.
> 
> **Overview**
> Removes the `cargoLock.outputHashes` override (previously pinning `orgize-0.10.0-alpha.10`) from `flake.nix`, leaving `buildRustPackage` to use only `Cargo.lock` for dependency locking.
> 
> This is a build/config-only change that alters how Nix resolves/pins Cargo dependencies during `nix build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913fb246e48b97b5f4fdfc2971f7ea547cc4cffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->