### PR TITLE
fix(nix): use makeRustPlatform to wire stable toolchain into buildRustPackage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,10 +56,15 @@
             "llvm-tools-preview"
           ];
         };
+
+        rustPlatform = pkgsWithOverlay.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
       in {
         packages = {
           default = self'.packages.org-mcp;
-          org-mcp = pkgsWithOverlay.rustPlatform.buildRustPackage rec {
+          org-mcp = rustPlatform.buildRustPackage rec {
             pname = "org-mcp-server";
             version = let
               cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
@@ -71,10 +76,8 @@
               lockFile = ./Cargo.lock;
             };
 
-            nativeBuildInputs = [
-              rustToolchain
-            ];
-            buildInputs = nativeBuildInputs;
+            nativeBuildInputs = [];
+            buildInputs = [];
             meta = with pkgs.lib; {
               description = "OrgMode MCP Server Full";
               homepage = "https://github.com/szaffarano/org-mcp-server";


### PR DESCRIPTION
Previously rustPlatform was taken from pkgsWithOverlay directly, which caused rust-overlay's implicit nightly replacement to be used for compilation, ignoring the rustToolchain variable entirely.
