### PR TITLE
feat(org): add org-update-todo tool and CLI command for updating TODOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Coverage reports
 /coverage
 result
+.omo

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ linking capabilities for your org-mode files through the MCP protocol.
   priority, tags, body, SCHEDULED/DEADLINE/CLOSED timestamps (with optional repeater
   and warning suffixes), property drawer entries, and Year/Month/Day datetree expansion.
   Can target a specific heading or append to end of file.
+- `org-update-todo` — Update the TODO state and planning metadata of an existing
+  heading (target by org ID or file + heading path). Set or clear todo_state, priority,
+  tags, and SCHEDULED/DEADLINE/CLOSED timestamps. CLOSED is auto-managed on done/active
+  transitions (disable with `org_auto_closed_timestamp = false`).
 
 ### CLI Tool
 
@@ -56,6 +60,9 @@ linking capabilities for your org-mode files through the MCP protocol.
 - `org-cli agenda range` — Show tasks in custom date range
 - `org-cli capture` — Append a new heading to an org file with optional TODO state,
   priority, tags, body, planning timestamps, property drawer, and datetree expansion
+- `org-cli update-todo` — Update an existing heading's TODO state, priority, tags, and
+  planning timestamps in place; supports clearing fields via `--clear` and auto-stamps
+  CLOSED on done transitions
 
 ## Configuration
 
@@ -92,6 +99,9 @@ org_todo_keywords = [
 # `:CREATED: [YYYY-MM-DD Day HH:MM]` (with the current local time) to the property
 # drawer of new entries. User-supplied CREATED (case-insensitive) wins.
 org_auto_created_property = true
+# When true, updating a TODO to a done keyword automatically stamps CLOSED with the
+# current local time, and reactivating a done task removes its CLOSED timestamp.
+org_auto_closed_timestamp = true
 
 [logging]
 # Log level: trace, debug, info, warn, error
@@ -112,6 +122,8 @@ default_format = "plain"  # plain | json
 - `ORG_ORG__ORG_AGENDA_FILES` — Comma-separated list of agenda files
 - `ORG_ORG__ORG_AGENDA_TEXT_SEARCH_EXTRA_FILES` — Comma-separated extra search files
 - `ORG_ORG__ORG_AUTO_CREATED_PROPERTY` — `true`/`false`; auto-add `:CREATED:` on capture (default: true)
+- `ORG_ORG__ORG_AUTO_CLOSED_TIMESTAMP` — `true`/`false`; auto-manage `CLOSED` on todo
+  state transitions (default: true)
 
 #### Logging Configuration
 - `ORG_LOGGING__LEVEL` — Log level (debug, info, warn, error, trace)

--- a/README.md
+++ b/README.md
@@ -421,8 +421,9 @@ cargo run --example <name>
 ### Phase 3: Extended Capabilities 🚧
 
 - [x] Content creation via `org-capture` (heading + planning + properties + datetree)
-- [ ] Content modification (edit existing TODOs: state changes, planning updates,
-      property updates, CLOCK / LOGBOOK entries)
+- [x] Content modification: TODO state, priority, tags, and planning updates via
+      `org-update-todo` / `org-cli update-todo`
+- [ ] Content modification: property drawer updates and CLOCK / LOGBOOK entries
 - [ ] Media file reference handling
 - [ ] Integration with org-roam databases
 - [ ] Real-time file watching and updates

--- a/org-cli/src/commands/mod.rs
+++ b/org-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod list;
 pub mod outline;
 pub mod read;
 pub mod search;
+pub mod update_todo;
 
 pub use agenda::AgendaCommand;
 pub use capture::CaptureCommand;
@@ -17,3 +18,4 @@ pub use list::ListCommand;
 pub use outline::OutlineCommand;
 pub use read::ReadCommand;
 pub use search::SearchCommand;
+pub use update_todo::UpdateTodoCommand;

--- a/org-cli/src/commands/update_todo.rs
+++ b/org-cli/src/commands/update_todo.rs
@@ -1,0 +1,107 @@
+use crate::config::CliConfig;
+use anyhow::{Result, anyhow};
+use clap::Args;
+use org_core::{ClearField, OrgMode, UpdateEntry};
+
+#[derive(Args)]
+pub struct UpdateTodoCommand {
+    /// Org ID property of the target heading (wins over --file/--heading)
+    #[arg(long)]
+    id: Option<String>,
+
+    /// File path relative to org directory (requires --heading)
+    #[arg(short = 'F', long, requires = "heading")]
+    file: Option<String>,
+
+    /// Slash-separated heading path (e.g., 'Projects/Work'; requires --file)
+    #[arg(long, requires = "file")]
+    heading: Option<String>,
+
+    /// New TODO state keyword (must match a configured keyword)
+    #[arg(short = 's', long)]
+    todo_state: Option<String>,
+
+    /// New priority level: A, B, or C
+    #[arg(short = 'p', long)]
+    priority: Option<String>,
+
+    /// Replace tags (comma-separated). Each tag must match [A-Za-z0-9_@]+
+    #[arg(short = 't', long, value_delimiter = ',')]
+    tags: Option<Vec<String>>,
+
+    /// New SCHEDULED timestamp (ISO YYYY-MM-DD[ HH:MM] [repeater] [warning])
+    #[arg(long)]
+    scheduled: Option<String>,
+
+    /// New DEADLINE timestamp (same format as --scheduled)
+    #[arg(long)]
+    deadline: Option<String>,
+
+    /// CLOSED inactive timestamp (usually auto-managed on state transitions)
+    #[arg(long)]
+    closed: Option<String>,
+
+    /// Fields to remove: todo-state,priority,tags,scheduled,deadline,closed
+    #[arg(long, value_delimiter = ',')]
+    clear: Vec<String>,
+
+    /// Output format
+    #[arg(short = 'f', long)]
+    format: Option<OutputFormat>,
+}
+
+#[derive(clap::ValueEnum, Clone)]
+enum OutputFormat {
+    Plain,
+    Json,
+}
+
+impl UpdateTodoCommand {
+    pub fn execute(&self, org_mode: OrgMode, cli: CliConfig) -> Result<()> {
+        let clear = self
+            .clear
+            .iter()
+            .map(|s| {
+                s.parse::<ClearField>()
+                    .map_err(|e| anyhow!("invalid --clear value: {e}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let entry = UpdateEntry {
+            id: self.id.clone(),
+            file: self.file.clone(),
+            heading_path: self.heading.clone(),
+            todo_state: self.todo_state.clone(),
+            priority: self.priority.clone(),
+            tags: self.tags.clone(),
+            scheduled: self.scheduled.clone(),
+            deadline: self.deadline.clone(),
+            closed: self.closed.clone(),
+            clear,
+        };
+
+        let result = org_mode.update_todo(entry)?;
+
+        let format = self.format.as_ref().unwrap_or({
+            match cli.default_format.as_str() {
+                "json" => &OutputFormat::Json,
+                _ => &OutputFormat::Plain,
+            }
+        });
+
+        match format {
+            OutputFormat::Plain => {
+                println!("Updated {}", result.file_path);
+                println!("  {}", result.heading_line);
+                for change in &result.changes {
+                    println!("  {change}");
+                }
+            }
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/org-cli/src/commands/update_todo.rs
+++ b/org-cli/src/commands/update_todo.rs
@@ -1,9 +1,29 @@
 use crate::config::CliConfig;
 use anyhow::{Result, anyhow};
-use clap::Args;
+use clap::{ArgGroup, Args};
 use org_core::{ClearField, OrgMode, UpdateEntry};
 
 #[derive(Args)]
+#[command(group(
+    ArgGroup::new("target")
+        .args(["id", "file"])
+        .required(true)
+        .multiple(true),
+))]
+#[command(group(
+    ArgGroup::new("mutation")
+        .args([
+            "todo_state",
+            "priority",
+            "tags",
+            "scheduled",
+            "deadline",
+            "closed",
+            "clear",
+        ])
+        .required(true)
+        .multiple(true),
+))]
 pub struct UpdateTodoCommand {
     /// Org ID property of the target heading (wins over --file/--heading)
     #[arg(long)]

--- a/org-cli/src/main.rs
+++ b/org-cli/src/main.rs
@@ -51,7 +51,14 @@ enum Commands {
     UpdateTodo(UpdateTodoCommand),
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {

--- a/org-cli/src/main.rs
+++ b/org-cli/src/main.rs
@@ -6,7 +6,7 @@ mod commands;
 mod config;
 use commands::{
     AgendaCommand, CaptureCommand, ConfigCommand, ElementByIdCommand, HeadingCommand, ListCommand,
-    OutlineCommand, ReadCommand, SearchCommand,
+    OutlineCommand, ReadCommand, SearchCommand, UpdateTodoCommand,
 };
 use config::CliAppConfig;
 
@@ -47,6 +47,8 @@ enum Commands {
     ElementById(ElementByIdCommand),
     /// Search for text content across all org files using fuzzy matching
     Search(SearchCommand),
+    /// Update TODO state and planning metadata of an existing heading
+    UpdateTodo(UpdateTodoCommand),
 }
 
 fn main() -> Result<()> {
@@ -73,6 +75,7 @@ fn main() -> Result<()> {
                 Commands::Heading(cmd) => cmd.execute(org_mode, config.cli),
                 Commands::ElementById(cmd) => cmd.execute(org_mode, config.cli),
                 Commands::Search(cmd) => cmd.execute(org_mode, config.cli),
+                Commands::UpdateTodo(cmd) => cmd.execute(org_mode, config.cli),
             }
         }
     }

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -2028,3 +2028,64 @@ org_agenda_files = ["agenda.org"]
         .stdout(predicate::str::contains("Overdue deadline-only task"))
         .stdout(predicate::str::contains("14d ago").or(predicate::str::contains("15d ago")));
 }
+
+#[test]
+fn test_update_todo_by_id_plain_output() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--id")
+        .arg("task-groceries-456")
+        .arg("--todo-state")
+        .arg("DONE")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated notes.org"))
+        .stdout(predicate::str::contains("DONE Buy groceries"));
+
+    let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+    assert!(content.contains("DONE Buy groceries"));
+    assert!(content.contains("CLOSED: ["));
+}
+
+#[test]
+fn test_update_todo_json_output() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--file")
+        .arg("notes.org")
+        .arg("--heading")
+        .arg("Daily Tasks/Buy groceries")
+        .arg("--priority")
+        .arg("A")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"file_path\": \"notes.org\""))
+        .stdout(predicate::str::contains("[#A]"))
+        .stdout(predicate::str::contains("\"changes\""));
+}
+
+#[test]
+fn test_update_todo_not_found_fails() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--id")
+        .arg("no-such-id")
+        .arg("--todo-state")
+        .arg("DONE")
+        .assert()
+        .failure();
+}

--- a/org-cli/tests/integration_tests.rs
+++ b/org-cli/tests/integration_tests.rs
@@ -2089,3 +2089,58 @@ fn test_update_todo_not_found_fails() {
         .assert()
         .failure();
 }
+
+#[test]
+fn test_update_todo_missing_target_is_usage_error() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--todo-state")
+        .arg("DONE")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "required arguments were not provided",
+        ));
+}
+
+#[test]
+fn test_update_todo_missing_mutation_is_usage_error() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--file")
+        .arg("notes.org")
+        .arg("--heading")
+        .arg("Daily Tasks/Buy groceries")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "required arguments were not provided",
+        ));
+}
+
+#[test]
+fn test_update_todo_domain_error_has_no_backtrace() {
+    let temp_dir = setup_test_org_files_with_dates().unwrap();
+
+    cargo::cargo_bin_cmd!("org-cli")
+        .arg("--root-directory")
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("update-todo")
+        .arg("--id")
+        .arg("no-such-id")
+        .arg("--todo-state")
+        .arg("DONE")
+        .env("RUST_BACKTRACE", "1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error: Heading not found"))
+        .stderr(predicate::str::contains("Stack backtrace").not());
+}

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -7,7 +7,6 @@ ignore.workspace = true
 nucleo-matcher.workspace = true
 orgize = { workspace = true, features = ["tracing", "chrono"] }
 pastey.workspace = true
-regex.workspace = true
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 shellexpand.workspace = true

--- a/org-core/Cargo.toml
+++ b/org-core/Cargo.toml
@@ -7,6 +7,7 @@ ignore.workspace = true
 nucleo-matcher.workspace = true
 orgize = { workspace = true, features = ["tracing", "chrono"] }
 pastey.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 shellexpand.workspace = true

--- a/org-core/src/config.rs
+++ b/org-core/src/config.rs
@@ -23,6 +23,8 @@ pub struct OrgConfig {
     pub org_todo_keywords: Vec<String>,
     #[serde(default = "default_org_auto_created_property")]
     pub org_auto_created_property: bool,
+    #[serde(default = "default_org_auto_closed_timestamp")]
+    pub org_auto_closed_timestamp: bool,
 }
 
 /// Logging configuration (shared across CLI and server)
@@ -43,6 +45,7 @@ impl Default for OrgConfig {
             org_agenda_text_search_extra_files: Vec::default(),
             org_todo_keywords: default_todo_keywords(),
             org_auto_created_property: default_org_auto_created_property(),
+            org_auto_closed_timestamp: default_org_auto_closed_timestamp(),
         }
     }
 }
@@ -220,6 +223,10 @@ pub fn load_org_config(
         .set_default(
             "org.org_auto_created_property",
             default_org_auto_created_property(),
+        )?
+        .set_default(
+            "org.org_auto_closed_timestamp",
+            default_org_auto_closed_timestamp(),
         )?;
 
     let config = build_config_with_file_and_env(config_file, builder)?;
@@ -290,6 +297,10 @@ pub fn default_log_file() -> String {
 }
 
 pub fn default_org_auto_created_property() -> bool {
+    true
+}
+
+pub fn default_org_auto_closed_timestamp() -> bool {
     true
 }
 
@@ -758,5 +769,30 @@ file = "/var/log/test.log"
 
         let result = config.validate();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_org_auto_closed_timestamp_defaults_true() {
+        let config = OrgConfig::default();
+        assert!(config.org_auto_closed_timestamp);
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_auto_closed_timestamp_from_toml() {
+        let temp_dir = tempdir().unwrap();
+        let path_str = test_utils::config::normalize_path(temp_dir.path());
+        let toml_config = format!(
+            r#"
+[org]
+org_directory = "{path_str}"
+org_auto_closed_timestamp = false
+"#,
+        );
+
+        let config_path = test_utils::config::create_toml_config(&temp_dir, &toml_config).unwrap();
+
+        let config = load_org_config(Some(config_path.to_str().unwrap()), None).unwrap();
+        assert!(!config.org_auto_closed_timestamp);
     }
 }

--- a/org-core/src/error.rs
+++ b/org-core/src/error.rs
@@ -22,6 +22,9 @@ pub enum OrgModeError {
     DuplicatePropertyKey(String),
     InvalidDatetreeDate(String),
     DatetreeDateWithoutFlag,
+    HeadingNotFound(String),
+    AmbiguousTarget(String),
+    InvalidUpdate(String),
 }
 
 impl fmt::Display for OrgModeError {
@@ -74,6 +77,18 @@ impl fmt::Display for OrgModeError {
             }
             OrgModeError::DatetreeDateWithoutFlag => {
                 write!(f, "Datetree date specified without enabling datetree")
+            }
+            OrgModeError::HeadingNotFound(target) => {
+                write!(f, "Heading not found: {target}")
+            }
+            OrgModeError::AmbiguousTarget(target) => {
+                write!(
+                    f,
+                    "Ambiguous target (matches more than one heading): {target}"
+                )
+            }
+            OrgModeError::InvalidUpdate(reason) => {
+                write!(f, "Invalid update: {reason}")
             }
         }
     }
@@ -208,5 +223,32 @@ mod tests {
     fn test_display_datetree_date_without_flag() {
         let s = format!("{}", OrgModeError::DatetreeDateWithoutFlag);
         assert_eq!(s, "Datetree date specified without enabling datetree");
+    }
+
+    #[test]
+    fn test_display_heading_not_found() {
+        let s = format!("{}", OrgModeError::HeadingNotFound("task-123".to_string()));
+        assert_eq!(s, "Heading not found: task-123");
+    }
+
+    #[test]
+    fn test_display_ambiguous_target() {
+        let s = format!(
+            "{}",
+            OrgModeError::AmbiguousTarget("Projects/Work".to_string())
+        );
+        assert_eq!(
+            s,
+            "Ambiguous target (matches more than one heading): Projects/Work"
+        );
+    }
+
+    #[test]
+    fn test_display_invalid_update() {
+        let s = format!(
+            "{}",
+            OrgModeError::InvalidUpdate("nothing to update".to_string())
+        );
+        assert_eq!(s, "Invalid update: nothing to update");
     }
 }

--- a/org-core/src/lib.rs
+++ b/org-core/src/lib.rs
@@ -9,5 +9,6 @@ mod error_tests;
 pub use config::{LoggingConfig, OrgConfig};
 pub use error::OrgModeError;
 pub use org_mode::{
-    AgendaItem, AgendaView, CaptureEntry, CaptureResult, OrgMode, Priority, PropertyPair, TodoState,
+    AgendaItem, AgendaView, CaptureEntry, CaptureResult, ClearField, OrgMode, Priority,
+    PropertyPair, TodoState, UpdateEntry, UpdateResult,
 };

--- a/org-core/src/org_mode/capture.rs
+++ b/org-core/src/org_mode/capture.rs
@@ -32,7 +32,7 @@ struct ResolvedCapture {
     properties: Vec<PropertyPair>,
 }
 
-fn is_valid_tag(tag: &str) -> bool {
+pub(crate) fn is_valid_tag(tag: &str) -> bool {
     !tag.is_empty()
         && tag
             .chars()
@@ -519,7 +519,7 @@ impl OrgMode {
         Ok(parent.join(name))
     }
 
-    fn validate_relative_file_path(file_rel: &str) -> Result<(), OrgModeError> {
+    pub(crate) fn validate_relative_file_path(file_rel: &str) -> Result<(), OrgModeError> {
         use std::path::Component;
         let p = Path::new(file_rel);
         if p.is_absolute() {

--- a/org-core/src/org_mode/capture.rs
+++ b/org-core/src/org_mode/capture.rs
@@ -289,7 +289,7 @@ impl OrgMode {
         insert_text
     }
 
-    fn prepare_target_path(&self, file_rel: &str) -> Result<PathBuf, OrgModeError> {
+    pub(crate) fn prepare_target_path(&self, file_rel: &str) -> Result<PathBuf, OrgModeError> {
         let org_dir = PathBuf::from(&self.config.org_directory);
         let full_path = org_dir.join(file_rel);
 
@@ -500,7 +500,7 @@ impl OrgMode {
         })
     }
 
-    fn lock_path_for(target: &Path) -> Result<PathBuf, OrgModeError> {
+    pub(crate) fn lock_path_for(target: &Path) -> Result<PathBuf, OrgModeError> {
         let parent = target.parent().ok_or_else(|| {
             OrgModeError::IoError(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -558,7 +558,7 @@ impl OrgMode {
     }
 
     #[cfg(unix)]
-    fn acquire_capture_lock(lock_path: &Path) -> Result<std::fs::File, OrgModeError> {
+    pub(crate) fn acquire_capture_lock(lock_path: &Path) -> Result<std::fs::File, OrgModeError> {
         loop {
             let fd = OpenOptions::new()
                 .read(true)
@@ -581,7 +581,7 @@ impl OrgMode {
     }
 
     #[cfg(not(unix))]
-    fn acquire_capture_lock(lock_path: &Path) -> Result<std::fs::File, OrgModeError> {
+    pub(crate) fn acquire_capture_lock(lock_path: &Path) -> Result<std::fs::File, OrgModeError> {
         let fd = OpenOptions::new()
             .read(true)
             .write(true)
@@ -593,7 +593,7 @@ impl OrgMode {
         Ok(fd)
     }
 
-    fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), OrgModeError> {
+    pub(crate) fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), OrgModeError> {
         let parent = target.parent().ok_or_else(|| {
             OrgModeError::IoError(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -619,7 +619,7 @@ impl OrgMode {
         Ok(())
     }
 
-    fn format_heading(
+    pub(crate) fn format_heading(
         level: usize,
         todo_state: Option<&str>,
         priority: Option<&str>,

--- a/org-core/src/org_mode/mod.rs
+++ b/org-core/src/org_mode/mod.rs
@@ -2,6 +2,7 @@ mod agenda;
 mod capture;
 mod core;
 mod types;
+mod update;
 
 pub use types::*;
 

--- a/org-core/src/org_mode/types.rs
+++ b/org-core/src/org_mode/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Local};
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::config::OrgConfig;
 
@@ -137,6 +138,93 @@ pub struct CaptureResult {
     pub heading_line: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub under_target: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClearField {
+    TodoState,
+    Priority,
+    Tags,
+    Scheduled,
+    Deadline,
+    Closed,
+}
+
+impl std::fmt::Display for ClearField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            ClearField::TodoState => "todo_state",
+            ClearField::Priority => "priority",
+            ClearField::Tags => "tags",
+            ClearField::Scheduled => "scheduled",
+            ClearField::Deadline => "deadline",
+            ClearField::Closed => "closed",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl std::str::FromStr for ClearField {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "todo_state" | "todo-state" => Ok(ClearField::TodoState),
+            "priority" => Ok(ClearField::Priority),
+            "tags" => Ok(ClearField::Tags),
+            "scheduled" => Ok(ClearField::Scheduled),
+            "deadline" => Ok(ClearField::Deadline),
+            "closed" => Ok(ClearField::Closed),
+            other => Err(format!(
+                "invalid clear field '{other}': expected todo_state, priority, tags, \
+                 scheduled, deadline, or closed"
+            )),
+        }
+    }
+}
+
+impl Serialize for ClearField {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for ClearField {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(D::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub todo_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closed: Option<String>,
+    #[serde(default)]
+    pub clear: Vec<ClearField>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateResult {
+    pub file_path: String,
+    pub heading_line: String,
+    pub changes: Vec<String>,
 }
 
 impl TreeNode {

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -108,11 +108,13 @@ fn extract_planning(h: &orgize::ast::Headline, content: &str) -> (usize, usize, 
             let p_start: usize = p.start().into();
             let p_end: usize = p.end().into();
             let first_line = line_index_at(content, p_start);
+            // orgize's planning span ends at the first byte of the next node
+            // (i.e. it includes the trailing '\n' of each planning line), so
+            // counting newlines gives the exact number of lines to splice.
             let line_count = content[p_start..p_end]
                 .bytes()
                 .filter(|&b| b == b'\n')
-                .count()
-                + 1;
+                .count();
             let values = PlanningValues {
                 scheduled: p.scheduled().map(|ts| ts.raw()),
                 deadline: p.deadline().map(|ts| ts.raw()),
@@ -347,7 +349,6 @@ impl OrgMode {
         };
 
         let mut lines: Vec<String> = content.lines().map(String::from).collect();
-        let planning = parse_planning_block(&lines, target.line_idx);
 
         // Resulting field values: explicit set > clear > existing.
         let cleared = |f: ClearField| entry.clear.contains(&f);
@@ -374,7 +375,7 @@ impl OrgMode {
                 .scheduled
                 .as_ref()
                 .map(|ts| Self::format_org_timestamp(ts, true))
-                .or(planning.values.scheduled.clone())
+                .or(target.planning_values.scheduled.clone())
         };
         let new_deadline = if cleared(ClearField::Deadline) {
             None
@@ -383,7 +384,7 @@ impl OrgMode {
                 .deadline
                 .as_ref()
                 .map(|ts| Self::format_org_timestamp(ts, true))
-                .or(planning.values.deadline.clone())
+                .or(target.planning_values.deadline.clone())
         };
 
         let is_done = new_keyword
@@ -395,7 +396,7 @@ impl OrgMode {
         } else if let Some(ts) = &resolved.closed {
             Some(Self::format_org_timestamp(ts, false))
         } else if is_done {
-            match planning.values.closed.clone() {
+            match target.planning_values.closed.clone() {
                 Some(existing) => Some(existing),
                 None if self.config.org_auto_closed_timestamp => {
                     let now = chrono::Local::now();
@@ -415,7 +416,7 @@ impl OrgMode {
             // Reactivated or keyword-less heading: drop the stale CLOSED.
             None
         } else {
-            planning.values.closed.clone()
+            target.planning_values.closed.clone()
         };
 
         let new_headline = Self::format_heading(
@@ -435,7 +436,7 @@ impl OrgMode {
         lines[target.line_idx] = new_headline.clone();
         let replacement: Vec<String> = new_planning.into_iter().collect();
         lines.splice(
-            planning.first_line..planning.first_line + planning.line_count,
+            target.planning_first_line..target.planning_first_line + target.planning_line_count,
             replacement,
         );
 
@@ -474,19 +475,19 @@ impl OrgMode {
         Self::push_change(
             &mut changes,
             "scheduled",
-            planning.values.scheduled.as_deref(),
+            target.planning_values.scheduled.as_deref(),
             new_scheduled.as_deref(),
         );
         Self::push_change(
             &mut changes,
             "deadline",
-            planning.values.deadline.as_deref(),
+            target.planning_values.deadline.as_deref(),
             new_deadline.as_deref(),
         );
         Self::push_change(
             &mut changes,
             "closed",
-            planning.values.closed.as_deref(),
+            target.planning_values.closed.as_deref(),
             new_closed.as_deref(),
         );
 

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use orgize::export::{Container, Event, from_fn};
+use orgize::export::{Container, Event, from_fn, from_fn_with_ctx};
 use orgize::{Org, ParseConfig};
 use regex::Regex;
 
@@ -85,6 +85,9 @@ struct TargetHeadline {
     priority: Option<String>,
     tags: Vec<String>,
     ambiguity: Option<String>,
+    planning_first_line: usize,
+    planning_line_count: usize,
+    planning_values: PlanningValues,
 }
 
 fn line_index_at(content: &str, byte_offset: usize) -> usize {
@@ -92,6 +95,32 @@ fn line_index_at(content: &str, byte_offset: usize) -> usize {
         .bytes()
         .filter(|b| *b == b'\n')
         .count()
+}
+
+fn extract_planning(h: &orgize::ast::Headline, content: &str) -> (usize, usize, PlanningValues) {
+    match h.planning() {
+        None => (
+            line_index_at(content, h.start().into()) + 1,
+            0,
+            PlanningValues::default(),
+        ),
+        Some(p) => {
+            let p_start: usize = p.start().into();
+            let p_end: usize = p.end().into();
+            let first_line = line_index_at(content, p_start);
+            let line_count = content[p_start..p_end]
+                .bytes()
+                .filter(|&b| b == b'\n')
+                .count()
+                + 1;
+            let values = PlanningValues {
+                scheduled: p.scheduled().map(|ts| ts.raw()),
+                deadline: p.deadline().map(|ts| ts.raw()),
+                closed: p.closed().map(|ts| ts.raw()),
+            };
+            (first_line, line_count, values)
+        }
+    }
 }
 
 impl OrgMode {
@@ -268,7 +297,7 @@ impl OrgMode {
 
     fn file_contains_id(content: &str, id: &str) -> bool {
         let mut found = false;
-        let mut handler = from_fn(|event| {
+        let mut handler = from_fn_with_ctx(|event, ctx| {
             if let Event::Enter(Container::Headline(ref h)) = event
                 && h.properties()
                     .and_then(|props| {
@@ -280,6 +309,7 @@ impl OrgMode {
                     .is_some()
             {
                 found = true;
+                ctx.stop();
             }
         });
         Org::parse(content).traverse(&mut handler);
@@ -409,9 +439,14 @@ impl OrgMode {
             replacement,
         );
 
-        let mut out = lines.join("\n");
+        let newline = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut out = lines.join(newline);
         if content.ends_with('\n') {
-            out.push('\n');
+            out.push_str(newline);
         }
         Self::atomic_write(full_path, out.as_bytes())?;
 
@@ -481,7 +516,7 @@ impl OrgMode {
         let mut matches: Vec<TargetHeadline> = Vec::new();
 
         if let Some(ref id) = entry.id {
-            let mut handler = from_fn(|event| {
+            let mut handler = from_fn_with_ctx(|event, ctx| {
                 if let Event::Enter(Container::Headline(ref h)) = event {
                     let has_id = h
                         .properties()
@@ -493,6 +528,8 @@ impl OrgMode {
                         })
                         .is_some();
                     if has_id {
+                        let (planning_first_line, planning_line_count, planning_values) =
+                            extract_planning(h, content);
                         matches.push(TargetHeadline {
                             line_idx: line_index_at(content, h.start().into()),
                             level: h.level(),
@@ -501,7 +538,14 @@ impl OrgMode {
                             priority: h.priority().map(|p| p.to_string()),
                             tags: h.tags().map(|s| s.to_string()).collect(),
                             ambiguity: None,
+                            planning_first_line,
+                            planning_line_count,
+                            planning_values,
                         });
+                        // Two matches suffice to report ambiguity; stop early.
+                        if matches.len() == 2 {
+                            ctx.stop();
+                        }
                     }
                 }
             });
@@ -510,18 +554,9 @@ impl OrgMode {
             let path = entry.heading_path.clone().unwrap_or_default();
             let parts: Vec<&str> = path.split('/').collect();
             let mut stack: Vec<(usize, String)> = Vec::new();
-            let mut pending: Option<TargetHeadline> = None;
             let mut handler = from_fn(|event| {
                 if let Event::Enter(Container::Headline(ref h)) = event {
                     let level = h.level();
-                    // A pending match is a leaf only if the next sibling/ancestor
-                    // (any headline at level <= target) follows it; a deeper child
-                    // proves the previous match is a non-leaf parent.
-                    if let Some(p) = pending.take()
-                        && level <= p.level
-                    {
-                        matches.push(p);
-                    }
                     while stack.last().map(|(l, _)| *l >= level).unwrap_or(false) {
                         stack.pop();
                     }
@@ -535,7 +570,9 @@ impl OrgMode {
                             .map(|(_, t)| t.as_str())
                             .eq(parts.iter().copied())
                     {
-                        pending = Some(TargetHeadline {
+                        let (planning_first_line, planning_line_count, planning_values) =
+                            extract_planning(h, content);
+                        matches.push(TargetHeadline {
                             line_idx: line_index_at(content, h.start().into()),
                             level,
                             title: h.title_raw().trim_end().to_string(),
@@ -543,15 +580,14 @@ impl OrgMode {
                             priority: h.priority().map(|p| p.to_string()),
                             tags: h.tags().map(|s| s.to_string()).collect(),
                             ambiguity: None,
+                            planning_first_line,
+                            planning_line_count,
+                            planning_values,
                         });
                     }
                 }
             });
             org.traverse(&mut handler);
-            // End of file: any remaining pending is a leaf.
-            if let Some(p) = pending.take() {
-                matches.push(p);
-            }
         }
 
         match matches.len() {
@@ -570,6 +606,9 @@ impl OrgMode {
                     priority: None,
                     tags: vec![],
                     ambiguity: Some(shown),
+                    planning_first_line: 0,
+                    planning_line_count: 0,
+                    planning_values: PlanningValues::default(),
                 }))
             }
         }
@@ -967,10 +1006,39 @@ Body line must survive.
         ));
 
         e.heading_path = Some("Daily Tasks".to_string());
-        assert!(matches!(
-            org_mode.update_todo(e).unwrap_err(),
-            OrgModeError::HeadingNotFound(_)
-        ));
+        // Non-leaf paths are valid targets: "Daily Tasks" has children but is a
+        // unique full-path match. Guards the behavior flipped by PR review.
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "* DONE Daily Tasks");
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(content.contains("* DONE Daily Tasks"));
+    }
+
+    #[test]
+    fn test_update_preserves_crlf_line_endings() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("crlf.org"),
+            "* TODO Task\r\nSCHEDULED: <2026-05-15 Fri>\r\nbody\r\n",
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("irrelevant");
+        e.id = None;
+        e.file = Some("crlf.org".to_string());
+        e.heading_path = Some("Task".to_string());
+        e.todo_state = Some("DONE".to_string());
+        org_mode.update_todo(e).unwrap();
+
+        let content = fs::read_to_string(temp_dir.path().join("crlf.org")).unwrap();
+        assert!(content.contains("* DONE Task\r\n"));
+        assert!(content.contains("\r\nbody\r\n"));
+        assert!(content.contains("CLOSED: ["));
+        assert!(
+            !content.replace("\r\n", "").contains('\n'),
+            "found bare LF after CRLF update:\n{content}"
+        );
     }
 
     #[test]

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -69,19 +69,56 @@ fn extract_planning(h: &orgize::ast::Headline, content: &str) -> (usize, usize, 
             let p_start: usize = p.start().into();
             let p_end: usize = p.end().into();
             let first_line = line_index_at(content, p_start);
-            // orgize's planning span ends at the first byte of the next node
-            // (i.e. it includes the trailing '\n' of each planning line), so
-            // counting newlines gives the exact number of lines to splice.
-            let line_count = content[p_start..p_end]
+            // orgize's planning span ends before the trailing '\n' only at EOF; max(1) guards that.
+            let ast_line_count = content[p_start..p_end]
                 .bytes()
                 .filter(|&b| b == b'\n')
-                .count();
-            let values = PlanningValues {
+                .count()
+                .max(1);
+            let mut values = PlanningValues {
                 scheduled: p.scheduled().map(|ts| ts.raw()),
                 deadline: p.deadline().map(|ts| ts.raw()),
                 closed: p.closed().map(|ts| ts.raw()),
             };
-            (first_line, line_count, values)
+            // Extend line_count over any additional consecutive planning lines that
+            // orgize does not include in its span (non-standard but written by some tools).
+            // Also extract any timestamps from those extra lines so they survive the splice.
+            let all_lines: Vec<&str> = content.lines().collect();
+            let mut extra = 0;
+            let mut next = first_line + ast_line_count;
+            while let Some(line) = all_lines.get(next) {
+                let t = line.trim_start();
+                let keyword = if t.starts_with("SCHEDULED:") {
+                    Some("SCHEDULED")
+                } else if t.starts_with("DEADLINE:") {
+                    Some("DEADLINE")
+                } else if t.starts_with("CLOSED:") {
+                    Some("CLOSED")
+                } else {
+                    None
+                };
+                if let Some(kw) = keyword {
+                    // Extract the raw timestamp (everything after "KEYWORD: ").
+                    let raw = t[kw.len()..].trim_start_matches(':').trim().to_string();
+                    match kw {
+                        "SCHEDULED" if values.scheduled.is_none() => {
+                            values.scheduled = Some(raw);
+                        }
+                        "DEADLINE" if values.deadline.is_none() => {
+                            values.deadline = Some(raw);
+                        }
+                        "CLOSED" if values.closed.is_none() => {
+                            values.closed = Some(raw);
+                        }
+                        _ => {}
+                    }
+                    extra += 1;
+                    next += 1;
+                } else {
+                    break;
+                }
+            }
+            (first_line, ast_line_count + extra, values)
         }
     }
 }
@@ -1144,5 +1181,76 @@ Body line must survive.
         org_mode.update_todo(e).unwrap();
 
         assert!(!temp_dir.path().join(".notes.org.lock").exists());
+    }
+
+    #[test]
+    fn test_update_planning_at_eof_no_trailing_newline() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("eof.org"),
+            "* TODO Task\nSCHEDULED: <2026-05-15 Fri>", // no trailing newline
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let e = UpdateEntry {
+            id: None,
+            file: Some("eof.org".to_string()),
+            heading_path: Some("Task".to_string()),
+            todo_state: Some("DONE".to_string()),
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![],
+        };
+        org_mode.update_todo(e).unwrap();
+        let content = fs::read_to_string(temp_dir.path().join("eof.org")).unwrap();
+        // Must not contain a duplicate SCHEDULED line
+        assert_eq!(
+            content.matches("SCHEDULED:").count(),
+            1,
+            "duplicate planning line:\n{content}"
+        );
+        assert!(content.contains("* DONE Task"));
+    }
+
+    #[test]
+    fn test_update_multi_line_planning_no_orphan() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("multi.org"),
+            "* TODO Task\nSCHEDULED: <2026-05-15 Fri>\nDEADLINE: <2026-05-20 Wed>\nbody\n",
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let e = UpdateEntry {
+            id: None,
+            file: Some("multi.org".to_string()),
+            heading_path: Some("Task".to_string()),
+            todo_state: Some("DONE".to_string()),
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![],
+        };
+        org_mode.update_todo(e).unwrap();
+        let content = fs::read_to_string(temp_dir.path().join("multi.org")).unwrap();
+        assert_eq!(
+            content.matches("SCHEDULED:").count(),
+            1,
+            "duplicate SCHEDULED:\n{content}"
+        );
+        assert_eq!(
+            content.matches("DEADLINE:").count(),
+            1,
+            "duplicate DEADLINE:\n{content}"
+        );
+        assert!(
+            content.contains("body"),
+            "body line must survive:\n{content}"
+        );
     }
 }

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -1,0 +1,281 @@
+use std::collections::HashSet;
+
+use crate::OrgModeError;
+use crate::org_mode::capture::ParsedTimestamp;
+use crate::org_mode::{ClearField, OrgMode, UpdateEntry};
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct ResolvedUpdate {
+    pub file_rel: Option<String>,
+    pub scheduled: Option<ParsedTimestamp>,
+    pub deadline: Option<ParsedTimestamp>,
+    pub closed: Option<ParsedTimestamp>,
+}
+
+impl OrgMode {
+    #[allow(dead_code)]
+    pub(crate) fn validate_update(
+        &self,
+        entry: &UpdateEntry,
+    ) -> Result<ResolvedUpdate, OrgModeError> {
+        // Targeting: id OR (file + heading_path); id wins when both are given.
+        if entry.file.is_some() != entry.heading_path.is_some() {
+            return Err(OrgModeError::InvalidUpdate(
+                "file and heading_path must be given together".to_string(),
+            ));
+        }
+        if entry.id.is_none() && entry.file.is_none() {
+            return Err(OrgModeError::InvalidUpdate(
+                "target required: pass id or file + heading_path".to_string(),
+            ));
+        }
+        if let Some(ref id) = entry.id
+            && id.trim().is_empty()
+        {
+            return Err(OrgModeError::InvalidUpdate(
+                "id must not be empty".to_string(),
+            ));
+        }
+        if let Some(ref path) = entry.heading_path {
+            for segment in path.split('/') {
+                if segment.trim().is_empty() {
+                    return Err(OrgModeError::InvalidHeadingPath(format!(
+                        "heading_path contains an empty or whitespace-only segment: '{path}'"
+                    )));
+                }
+            }
+        }
+
+        // At least one mutation.
+        if entry.todo_state.is_none()
+            && entry.priority.is_none()
+            && entry.tags.is_none()
+            && entry.scheduled.is_none()
+            && entry.deadline.is_none()
+            && entry.closed.is_none()
+            && entry.clear.is_empty()
+        {
+            return Err(OrgModeError::InvalidUpdate("nothing to update".to_string()));
+        }
+
+        // No field may be both set and cleared; no duplicate clear entries.
+        let mut seen: HashSet<ClearField> = HashSet::new();
+        for field in &entry.clear {
+            if !seen.insert(*field) {
+                return Err(OrgModeError::InvalidUpdate(format!(
+                    "duplicate clear entry '{field}'"
+                )));
+            }
+            let conflict = match field {
+                ClearField::TodoState => entry.todo_state.is_some(),
+                ClearField::Priority => entry.priority.is_some(),
+                ClearField::Tags => entry.tags.is_some(),
+                ClearField::Scheduled => entry.scheduled.is_some(),
+                ClearField::Deadline => entry.deadline.is_some(),
+                ClearField::Closed => entry.closed.is_some(),
+            };
+            if conflict {
+                return Err(OrgModeError::InvalidUpdate(format!(
+                    "field '{field}' is both set and cleared"
+                )));
+            }
+        }
+
+        if let Some(ref kw) = entry.todo_state {
+            let valid_keywords: Vec<&str> = self
+                .config
+                .org_todo_keywords
+                .iter()
+                .filter(|k| k.as_str() != "|")
+                .map(|k| k.as_str())
+                .collect();
+            if !valid_keywords.contains(&kw.as_str()) {
+                return Err(OrgModeError::InvalidTodoKeyword(kw.clone()));
+            }
+        }
+
+        if let Some(ref p) = entry.priority
+            && !matches!(p.as_str(), "A" | "B" | "C")
+        {
+            return Err(OrgModeError::InvalidPriority(p.clone()));
+        }
+
+        if let Some(ref tags) = entry.tags {
+            for tag in tags {
+                if !super::capture::is_valid_tag(tag) {
+                    return Err(OrgModeError::InvalidTag(tag.clone()));
+                }
+            }
+        }
+
+        let scheduled = entry
+            .scheduled
+            .as_deref()
+            .map(|v| Self::parse_iso_timestamp("scheduled", v))
+            .transpose()?;
+        let deadline = entry
+            .deadline
+            .as_deref()
+            .map(|v| Self::parse_iso_timestamp("deadline", v))
+            .transpose()?;
+        let closed = entry
+            .closed
+            .as_deref()
+            .map(|v| Self::parse_iso_timestamp("closed", v))
+            .transpose()?;
+
+        let file_rel = match entry.file {
+            Some(ref f) => {
+                Self::validate_relative_file_path(f)?;
+                Some(f.clone())
+            }
+            None => None,
+        };
+
+        Ok(ResolvedUpdate {
+            file_rel,
+            scheduled,
+            deadline,
+            closed,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::OrgConfig;
+
+    fn make_org_mode(temp_dir: &tempfile::TempDir) -> OrgMode {
+        OrgMode::new(OrgConfig {
+            org_directory: temp_dir.path().to_str().unwrap().to_string(),
+            ..OrgConfig::default()
+        })
+        .unwrap()
+    }
+
+    fn entry_by_path() -> UpdateEntry {
+        UpdateEntry {
+            id: None,
+            file: Some("notes.org".to_string()),
+            heading_path: Some("Daily Tasks/Buy groceries".to_string()),
+            todo_state: Some("DONE".to_string()),
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![],
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_missing_target() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.file = None;
+        e.heading_path = None;
+        let err = org_mode.validate_update(&e).unwrap_err();
+        assert!(matches!(err, OrgModeError::InvalidUpdate(_)));
+    }
+
+    #[test]
+    fn test_validate_rejects_file_without_heading_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.heading_path = None;
+        let err = org_mode.validate_update(&e).unwrap_err();
+        assert!(matches!(err, OrgModeError::InvalidUpdate(_)));
+    }
+
+    #[test]
+    fn test_validate_rejects_noop() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        let err = org_mode.validate_update(&e).unwrap_err();
+        match err {
+            OrgModeError::InvalidUpdate(msg) => assert_eq!(msg, "nothing to update"),
+            other => panic!("expected InvalidUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_set_and_clear_same_field() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        e.scheduled = Some("2026-05-15".to_string());
+        e.clear = vec![ClearField::Scheduled];
+        let err = org_mode.validate_update(&e).unwrap_err();
+        match err {
+            OrgModeError::InvalidUpdate(msg) => assert!(msg.contains("scheduled")),
+            other => panic!("expected InvalidUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_keyword_priority_tag() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = entry_by_path();
+        e.todo_state = Some("MAYBE".to_string());
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidTodoKeyword(_)
+        ));
+
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        e.priority = Some("Z".to_string());
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidPriority(_)
+        ));
+
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        e.tags = Some(vec!["bad tag".to_string()]);
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidTag(_)
+        ));
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_timestamp_and_traversal() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        e.scheduled = Some("tomorrow".to_string());
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidTimestamp { .. }
+        ));
+
+        let mut e = entry_by_path();
+        e.file = Some("../escape.org".to_string());
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidDirectory(_)
+        ));
+    }
+
+    #[test]
+    fn test_validate_accepts_clear_only_update() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.todo_state = None;
+        e.clear = vec![ClearField::Priority];
+        assert!(org_mode.validate_update(&e).is_ok());
+    }
+}

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -503,7 +503,7 @@ impl OrgMode {
                         matches.push(TargetHeadline {
                             line_idx: line_index_at(content, h.start().into()),
                             level: h.level(),
-                            title: h.title_raw(),
+                            title: h.title_raw().trim_end().to_string(),
                             keyword: h.todo_keyword().map(|t| t.to_string()),
                             priority: h.priority().map(|p| p.to_string()),
                             tags: h.tags().map(|s| s.to_string()).collect(),
@@ -997,5 +997,173 @@ Body line must survive.
             org_mode.update_todo(e).unwrap_err(),
             OrgModeError::AmbiguousTarget(_)
         ));
+    }
+
+    #[test]
+    fn test_update_by_id_preserves_single_spacing_with_tags() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("ids.org"),
+            "* TODO Tagged task :a:b:\n:PROPERTIES:\n:ID: tagged-1\n:END:\nbody\n",
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("tagged-1");
+        e.priority = Some("A".to_string());
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "* TODO [#A] Tagged task :a:b:");
+        let content = fs::read_to_string(temp_dir.path().join("ids.org")).unwrap();
+        assert!(content.contains("* TODO [#A] Tagged task :a:b:\n"));
+        assert!(content.contains("\nbody\n"));
+    }
+
+    #[test]
+    fn test_clear_scheduled_and_priority() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let e = UpdateEntry {
+            id: None,
+            file: Some("notes.org".to_string()),
+            heading_path: Some("Projects/Work/Refactor API".to_string()),
+            todo_state: None,
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![ClearField::Scheduled, ClearField::Priority],
+        };
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "*** TODO Refactor API");
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(
+            !content.contains("SCHEDULED:"),
+            "planning line removed:\n{content}"
+        );
+        assert!(content.contains("Body line must survive."));
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.starts_with("scheduled: ") && c.ends_with("-> <none>")),
+            "expected a scheduled removal entry, got {:?}",
+            result.changes
+        );
+    }
+
+    #[test]
+    fn test_clear_todo_state_strips_keyword_and_closed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("task-book-789");
+        e.clear = vec![ClearField::TodoState];
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "** Read book");
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(
+            !content.contains("CLOSED:"),
+            "CLOSED removed with keyword:\n{content}"
+        );
+    }
+
+    #[test]
+    fn test_clear_tags_only() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("tags.org"),
+            "* TODO Tagged task :a:b:\nbody\n",
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let e = UpdateEntry {
+            id: None,
+            file: Some("tags.org".to_string()),
+            heading_path: Some("Tagged task".to_string()),
+            todo_state: None,
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![ClearField::Tags],
+        };
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "* TODO Tagged task");
+        let content = fs::read_to_string(temp_dir.path().join("tags.org")).unwrap();
+        assert_eq!(content, "* TODO Tagged task\nbody\n");
+    }
+
+    #[test]
+    fn test_planning_lands_before_property_drawer() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("task-groceries-456");
+        e.scheduled = Some("2026-05-18".to_string());
+        org_mode.update_todo(e).unwrap();
+
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        let block_start = content.find("** TODO Buy groceries").unwrap();
+        let rest = &content[block_start..];
+        let planning_pos = rest.find("SCHEDULED: <2026-05-18 Mon>").unwrap();
+        let drawer_pos = rest.find(":PROPERTIES:").unwrap();
+        assert!(
+            planning_pos < drawer_pos,
+            "planning line must come before the property drawer:\n{rest}"
+        );
+    }
+
+    #[test]
+    fn test_auto_closed_disabled_keeps_stale_closed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = OrgMode::new(OrgConfig {
+            org_directory: temp_dir.path().to_str().unwrap().to_string(),
+            org_auto_closed_timestamp: false,
+            ..OrgConfig::default()
+        })
+        .unwrap();
+
+        let mut e = update_by_id("task-book-789");
+        e.todo_state = Some("TODO".to_string());
+        org_mode.update_todo(e.clone()).unwrap();
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(content.contains("** TODO Read book"));
+        assert!(
+            content.contains("CLOSED: [2026-05-01 Fri 09:00]"),
+            "config off keeps existing CLOSED:\n{content}"
+        );
+
+        // and no auto-stamp on a fresh DONE either
+        let mut e2 = update_by_id("task-groceries-456");
+        e2.todo_state = Some("DONE".to_string());
+        org_mode.update_todo(e2).unwrap();
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        let groceries = &content[content.find("** DONE Buy groceries").unwrap()..];
+        assert!(
+            !groceries.lines().nth(1).unwrap_or("").contains("CLOSED:"),
+            "config off must not stamp CLOSED:\n{groceries}"
+        );
+        let _ = e;
+    }
+
+    #[test]
+    fn test_lock_file_cleaned_up() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("task-groceries-456");
+        e.priority = Some("B".to_string());
+        org_mode.update_todo(e).unwrap();
+
+        assert!(!temp_dir.path().join(".notes.org.lock").exists());
     }
 }

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -1,11 +1,15 @@
 use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
+use orgize::export::{Container, Event, from_fn};
+use orgize::{Org, ParseConfig};
 use regex::Regex;
 
 use crate::OrgModeError;
 use crate::org_mode::capture::ParsedTimestamp;
-use crate::org_mode::{ClearField, OrgMode, UpdateEntry};
+use crate::org_mode::{ClearField, OrgMode, UpdateEntry, UpdateResult};
 
 static PLANNING_LINE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(?:SCHEDULED|DEADLINE|CLOSED):").unwrap());
@@ -66,16 +70,33 @@ pub(crate) fn render_planning_line(values: &PlanningValues) -> Option<String> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) struct ResolvedUpdate {
+    #[allow(dead_code)]
     pub file_rel: Option<String>,
     pub scheduled: Option<ParsedTimestamp>,
     pub deadline: Option<ParsedTimestamp>,
     pub closed: Option<ParsedTimestamp>,
 }
 
+#[derive(Debug)]
+struct TargetHeadline {
+    line_idx: usize,
+    level: usize,
+    title: String,
+    keyword: Option<String>,
+    priority: Option<String>,
+    tags: Vec<String>,
+    ambiguity: Option<String>,
+}
+
+fn line_index_at(content: &str, byte_offset: usize) -> usize {
+    content[..byte_offset]
+        .bytes()
+        .filter(|b| *b == b'\n')
+        .count()
+}
+
 impl OrgMode {
-    #[allow(dead_code)]
     pub(crate) fn validate_update(
         &self,
         entry: &UpdateEntry,
@@ -200,6 +221,365 @@ impl OrgMode {
             deadline,
             closed,
         })
+    }
+
+    pub fn update_todo(&self, entry: UpdateEntry) -> Result<UpdateResult, OrgModeError> {
+        let resolved = self.validate_update(&entry)?;
+        let (file_rel, full_path) = self.resolve_target_file(&entry)?;
+
+        let lock_path = Self::lock_path_for(&full_path)?;
+        let lock_file = Self::acquire_capture_lock(&lock_path)?;
+
+        let result = self.apply_update(&file_rel, &full_path, &entry, &resolved);
+
+        // Same lock-release dance as capture_append.
+        #[cfg(unix)]
+        let _ = fs::remove_file(&lock_path);
+        drop(lock_file);
+        #[cfg(not(unix))]
+        let _ = fs::remove_file(&lock_path);
+
+        result
+    }
+
+    fn resolve_target_file(&self, entry: &UpdateEntry) -> Result<(String, PathBuf), OrgModeError> {
+        if let Some(ref id) = entry.id {
+            let mut matches: Vec<String> = Vec::new();
+            for path in self.list_files(None, None)? {
+                let content = self.read_file(&path)?;
+                if Self::file_contains_id(&content, id) {
+                    matches.push(path);
+                }
+            }
+            return match matches.len() {
+                0 => Err(OrgModeError::HeadingNotFound(id.clone())),
+                1 => {
+                    let file_rel = matches.pop().unwrap();
+                    let full_path = self.prepare_target_path(&file_rel)?;
+                    Ok((file_rel, full_path))
+                }
+                _ => Err(OrgModeError::AmbiguousTarget(id.clone())),
+            };
+        }
+
+        let file_rel = entry.file.clone().unwrap();
+        let full_path = PathBuf::from(&self.config.org_directory).join(&file_rel);
+        if !full_path.is_file() {
+            return Err(OrgModeError::HeadingNotFound(format!(
+                "{file_rel} (file does not exist)"
+            )));
+        }
+        let full_path = self.prepare_target_path(&file_rel)?;
+        Ok((file_rel, full_path))
+    }
+
+    fn file_contains_id(content: &str, id: &str) -> bool {
+        let mut found = false;
+        let mut handler = from_fn(|event| {
+            if let Event::Enter(Container::Headline(ref h)) = event
+                && h.properties()
+                    .and_then(|props| {
+                        props
+                            .to_hash_map()
+                            .into_iter()
+                            .find(|(k, v)| k.to_lowercase() == "id" && v == id)
+                    })
+                    .is_some()
+            {
+                found = true;
+            }
+        });
+        Org::parse(content).traverse(&mut handler);
+        found
+    }
+
+    fn apply_update(
+        &self,
+        file_rel: &str,
+        full_path: &PathBuf,
+        entry: &UpdateEntry,
+        resolved: &ResolvedUpdate,
+    ) -> Result<UpdateResult, OrgModeError> {
+        let content = fs::read_to_string(full_path).map_err(OrgModeError::IoError)?;
+
+        let parse_config = ParseConfig {
+            todo_keywords: (
+                self.config.unfinished_keywords(),
+                self.config.finished_keywords(),
+            ),
+            ..Default::default()
+        };
+        let org = parse_config.parse(&content);
+
+        let target = match self.locate_headline(&org, &content, entry)? {
+            Some(t) if t.ambiguity.is_none() => t,
+            Some(t) => return Err(OrgModeError::AmbiguousTarget(t.ambiguity.unwrap())),
+            None => {
+                let shown = entry
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| entry.heading_path.clone().unwrap_or_default());
+                return Err(OrgModeError::HeadingNotFound(shown));
+            }
+        };
+
+        let mut lines: Vec<String> = content.lines().map(String::from).collect();
+        let planning = parse_planning_block(&lines, target.line_idx);
+
+        // Resulting field values: explicit set > clear > existing.
+        let cleared = |f: ClearField| entry.clear.contains(&f);
+
+        let new_keyword = if cleared(ClearField::TodoState) {
+            None
+        } else {
+            entry.todo_state.clone().or(target.keyword.clone())
+        };
+        let new_priority = if cleared(ClearField::Priority) {
+            None
+        } else {
+            entry.priority.clone().or(target.priority.clone())
+        };
+        let new_tags = if cleared(ClearField::Tags) {
+            Vec::new()
+        } else {
+            entry.tags.clone().unwrap_or_else(|| target.tags.clone())
+        };
+        let new_scheduled = if cleared(ClearField::Scheduled) {
+            None
+        } else {
+            resolved
+                .scheduled
+                .as_ref()
+                .map(|ts| Self::format_org_timestamp(ts, true))
+                .or(planning.values.scheduled.clone())
+        };
+        let new_deadline = if cleared(ClearField::Deadline) {
+            None
+        } else {
+            resolved
+                .deadline
+                .as_ref()
+                .map(|ts| Self::format_org_timestamp(ts, true))
+                .or(planning.values.deadline.clone())
+        };
+
+        let is_done = new_keyword
+            .as_ref()
+            .map(|k| self.config.finished_keywords().contains(k))
+            .unwrap_or(false);
+        let new_closed = if cleared(ClearField::Closed) {
+            None
+        } else if let Some(ts) = &resolved.closed {
+            Some(Self::format_org_timestamp(ts, false))
+        } else if is_done {
+            match planning.values.closed.clone() {
+                Some(existing) => Some(existing),
+                None if self.config.org_auto_closed_timestamp => {
+                    let now = chrono::Local::now();
+                    Some(Self::format_org_timestamp(
+                        &ParsedTimestamp {
+                            date: now.date_naive(),
+                            time: Some(now.time()),
+                            repeater: None,
+                            warning: None,
+                        },
+                        false,
+                    ))
+                }
+                None => None,
+            }
+        } else if self.config.org_auto_closed_timestamp {
+            // Reactivated or keyword-less heading: drop the stale CLOSED.
+            None
+        } else {
+            planning.values.closed.clone()
+        };
+
+        let new_headline = Self::format_heading(
+            target.level,
+            new_keyword.as_deref(),
+            new_priority.as_deref(),
+            &target.title,
+            Some(&new_tags),
+        );
+        let new_planning = render_planning_line(&PlanningValues {
+            scheduled: new_scheduled.clone(),
+            deadline: new_deadline.clone(),
+            closed: new_closed.clone(),
+        });
+
+        // Splice: headline line replaced; planning block (0..n lines) replaced by 0..1 lines.
+        lines[target.line_idx] = new_headline.clone();
+        let replacement: Vec<String> = new_planning.into_iter().collect();
+        lines.splice(
+            planning.first_line..planning.first_line + planning.line_count,
+            replacement,
+        );
+
+        let mut out = lines.join("\n");
+        if content.ends_with('\n') {
+            out.push('\n');
+        }
+        Self::atomic_write(full_path, out.as_bytes())?;
+
+        let mut changes = Vec::new();
+        Self::push_change(
+            &mut changes,
+            "todo_state",
+            target.keyword.as_deref(),
+            new_keyword.as_deref(),
+        );
+        Self::push_change(
+            &mut changes,
+            "priority",
+            target.priority.as_deref(),
+            new_priority.as_deref(),
+        );
+        let old_tags = target.tags.join(":");
+        let new_tags_joined = new_tags.join(":");
+        Self::push_change(
+            &mut changes,
+            "tags",
+            (!old_tags.is_empty()).then_some(old_tags.as_str()),
+            (!new_tags_joined.is_empty()).then_some(new_tags_joined.as_str()),
+        );
+        Self::push_change(
+            &mut changes,
+            "scheduled",
+            planning.values.scheduled.as_deref(),
+            new_scheduled.as_deref(),
+        );
+        Self::push_change(
+            &mut changes,
+            "deadline",
+            planning.values.deadline.as_deref(),
+            new_deadline.as_deref(),
+        );
+        Self::push_change(
+            &mut changes,
+            "closed",
+            planning.values.closed.as_deref(),
+            new_closed.as_deref(),
+        );
+
+        Ok(UpdateResult {
+            file_path: file_rel.to_string(),
+            heading_line: new_headline,
+            changes,
+        })
+    }
+
+    fn push_change(changes: &mut Vec<String>, name: &str, old: Option<&str>, new: Option<&str>) {
+        if old != new {
+            changes.push(format!(
+                "{name}: {} -> {}",
+                old.unwrap_or("<none>"),
+                new.unwrap_or("<none>")
+            ));
+        }
+    }
+
+    fn locate_headline(
+        &self,
+        org: &Org,
+        content: &str,
+        entry: &UpdateEntry,
+    ) -> Result<Option<TargetHeadline>, OrgModeError> {
+        let mut matches: Vec<TargetHeadline> = Vec::new();
+
+        if let Some(ref id) = entry.id {
+            let mut handler = from_fn(|event| {
+                if let Event::Enter(Container::Headline(ref h)) = event {
+                    let has_id = h
+                        .properties()
+                        .and_then(|props| {
+                            props
+                                .to_hash_map()
+                                .into_iter()
+                                .find(|(k, v)| k.to_lowercase() == "id" && v == id)
+                        })
+                        .is_some();
+                    if has_id {
+                        matches.push(TargetHeadline {
+                            line_idx: line_index_at(content, h.start().into()),
+                            level: h.level(),
+                            title: h.title_raw(),
+                            keyword: h.todo_keyword().map(|t| t.to_string()),
+                            priority: h.priority().map(|p| p.to_string()),
+                            tags: h.tags().map(|s| s.to_string()).collect(),
+                            ambiguity: None,
+                        });
+                    }
+                }
+            });
+            org.traverse(&mut handler);
+        } else {
+            let path = entry.heading_path.clone().unwrap_or_default();
+            let parts: Vec<&str> = path.split('/').collect();
+            let mut stack: Vec<(usize, String)> = Vec::new();
+            let mut pending: Option<TargetHeadline> = None;
+            let mut handler = from_fn(|event| {
+                if let Event::Enter(Container::Headline(ref h)) = event {
+                    let level = h.level();
+                    // A pending match is a leaf only if the next sibling/ancestor
+                    // (any headline at level <= target) follows it; a deeper child
+                    // proves the previous match is a non-leaf parent.
+                    if let Some(p) = pending.take()
+                        && level <= p.level
+                    {
+                        matches.push(p);
+                    }
+                    while stack.last().map(|(l, _)| *l >= level).unwrap_or(false) {
+                        stack.pop();
+                    }
+                    // orgize's title_raw() keeps the title/tags separator as a
+                    // trailing space once tags are present; trim so user-supplied
+                    // path segments match the bare title.
+                    stack.push((level, h.title_raw().trim_end().to_string()));
+                    if stack.len() == parts.len()
+                        && stack
+                            .iter()
+                            .map(|(_, t)| t.as_str())
+                            .eq(parts.iter().copied())
+                    {
+                        pending = Some(TargetHeadline {
+                            line_idx: line_index_at(content, h.start().into()),
+                            level,
+                            title: h.title_raw().trim_end().to_string(),
+                            keyword: h.todo_keyword().map(|t| t.to_string()),
+                            priority: h.priority().map(|p| p.to_string()),
+                            tags: h.tags().map(|s| s.to_string()).collect(),
+                            ambiguity: None,
+                        });
+                    }
+                }
+            });
+            org.traverse(&mut handler);
+            // End of file: any remaining pending is a leaf.
+            if let Some(p) = pending.take() {
+                matches.push(p);
+            }
+        }
+
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(matches.pop().map(Some).unwrap()),
+            _ => {
+                let shown = entry
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| entry.heading_path.clone().unwrap_or_default());
+                Ok(Some(TargetHeadline {
+                    line_idx: 0,
+                    level: 0,
+                    title: String::new(),
+                    keyword: None,
+                    priority: None,
+                    tags: vec![],
+                    ambiguity: Some(shown),
+                }))
+            }
+        }
     }
 }
 
@@ -406,5 +786,216 @@ mod tests {
             Some("SCHEDULED: <2026-05-15 Fri> CLOSED: [2026-05-16 Sat]")
         );
         assert_eq!(render_planning_line(&PlanningValues::default()), None);
+    }
+
+    use crate::org_mode::UpdateResult;
+    use std::fs;
+
+    const FIXTURE: &str = "\
+* Daily Tasks
+:PROPERTIES:
+:ID: daily-tasks-123
+:END:
+** TODO Buy groceries
+:PROPERTIES:
+:ID: task-groceries-456
+:END:
+** DONE Read book
+CLOSED: [2026-05-01 Fri 09:00]
+:PROPERTIES:
+:ID: task-book-789
+:END:
+* Projects
+** Work
+*** TODO Refactor API
+SCHEDULED: <2026-05-15 Fri ++1w>
+Body line must survive.
+";
+
+    fn setup_fixture(temp_dir: &tempfile::TempDir) {
+        fs::write(temp_dir.path().join("notes.org"), FIXTURE).unwrap();
+    }
+
+    fn update_by_id(id: &str) -> UpdateEntry {
+        UpdateEntry {
+            id: Some(id.to_string()),
+            file: None,
+            heading_path: None,
+            todo_state: None,
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![],
+        }
+    }
+
+    #[test]
+    fn test_update_state_to_done_stamps_closed_by_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("task-groceries-456");
+        e.todo_state = Some("DONE".to_string());
+        let result: UpdateResult = org_mode.update_todo(e).unwrap();
+
+        assert_eq!(result.file_path, "notes.org");
+        assert_eq!(result.heading_line, "** DONE Buy groceries");
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(content.contains("** DONE Buy groceries"));
+        assert!(
+            content.contains(&format!("CLOSED: [{today}")),
+            "expected auto CLOSED stamp with today's date:\n{content}"
+        );
+        // property drawer must survive directly under the planning line
+        assert!(content.contains(":ID: task-groceries-456"));
+    }
+
+    #[test]
+    fn test_update_done_to_todo_removes_closed_by_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = UpdateEntry {
+            id: None,
+            file: Some("notes.org".to_string()),
+            heading_path: Some("Daily Tasks/Read book".to_string()),
+            todo_state: Some("TODO".to_string()),
+            priority: None,
+            tags: None,
+            scheduled: None,
+            deadline: None,
+            closed: None,
+            clear: vec![],
+        };
+        let result = org_mode.update_todo(e.clone()).unwrap();
+        assert_eq!(result.heading_line, "** TODO Read book");
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(
+            !content.contains("CLOSED:"),
+            "CLOSED must be removed:\n{content}"
+        );
+        assert!(content.contains(":ID: task-book-789"));
+
+        // id wins when both targeting forms are given
+        e.id = Some("task-groceries-456".to_string());
+        e.todo_state = Some("DONE".to_string());
+        let result = org_mode.update_todo(e).unwrap();
+        assert_eq!(result.heading_line, "** DONE Buy groceries");
+    }
+
+    #[test]
+    fn test_update_explicit_closed_wins_over_auto_stamp() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("task-groceries-456");
+        e.todo_state = Some("DONE".to_string());
+        e.closed = Some("2026-05-17 12:00".to_string());
+        org_mode.update_todo(e).unwrap();
+
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(content.contains("CLOSED: [2026-05-17 Sun 12:00]"));
+    }
+
+    #[test]
+    fn test_update_metadata_preserves_body_and_repeater() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = UpdateEntry {
+            id: None,
+            file: Some("notes.org".to_string()),
+            heading_path: Some("Projects/Work/Refactor API".to_string()),
+            todo_state: None,
+            priority: Some("A".to_string()),
+            tags: Some(vec!["backend".to_string()]),
+            scheduled: None,
+            deadline: Some("2026-05-20 17:00".to_string()),
+            closed: None,
+            clear: vec![],
+        };
+        let result = org_mode.update_todo(e.clone()).unwrap();
+        assert_eq!(result.heading_line, "*** TODO [#A] Refactor API :backend:");
+        let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        // untouched scheduled keeps its raw text including the repeater
+        assert!(content.contains("SCHEDULED: <2026-05-15 Fri ++1w>"));
+        assert!(content.contains("DEADLINE: <2026-05-20 Wed 17:00>"));
+        assert!(content.contains("Body line must survive."));
+
+        // everything outside the headline+planning span is byte-identical
+        e.priority = Some("B".to_string());
+        e.tags = None;
+        e.deadline = None;
+        org_mode.update_todo(e).unwrap();
+        let after = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
+        assert!(after.contains("*** TODO [#B] Refactor API :backend:"));
+        assert!(after.ends_with("Body line must survive.\n"));
+        assert!(after.starts_with("* Daily Tasks\n:PROPERTIES:\n:ID: daily-tasks-123"));
+    }
+
+    #[test]
+    fn test_update_target_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fixture(&temp_dir);
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("no-such-id");
+        e.todo_state = Some("DONE".to_string());
+        assert!(matches!(
+            org_mode.update_todo(e.clone()).unwrap_err(),
+            OrgModeError::HeadingNotFound(_)
+        ));
+
+        e.id = None;
+        e.file = Some("notes.org".to_string());
+        e.heading_path = Some("No/Such/Path".to_string());
+        assert!(matches!(
+            org_mode.update_todo(e.clone()).unwrap_err(),
+            OrgModeError::HeadingNotFound(_)
+        ));
+
+        e.heading_path = Some("Daily Tasks".to_string());
+        assert!(matches!(
+            org_mode.update_todo(e).unwrap_err(),
+            OrgModeError::HeadingNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn test_update_ambiguous_path_rejected() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("dup.org"),
+            "* A\n** TODO Dup\n* B\n** TODO Dup\n",
+        )
+        .unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+
+        let mut e = update_by_id("irrelevant");
+        e.id = None;
+        e.file = Some("dup.org".to_string());
+        e.heading_path = Some("B/Dup".to_string());
+        e.todo_state = Some("DONE".to_string());
+        // unique under B: works
+        org_mode.update_todo(e.clone()).unwrap();
+        // now make the remaining one ambiguous by checking a duplicated full path
+        fs::write(
+            temp_dir.path().join("dup2.org"),
+            "* X\n** TODO Same\n* X\n** TODO Same\n",
+        )
+        .unwrap();
+        e.file = Some("dup2.org".to_string());
+        e.heading_path = Some("X/Same".to_string());
+        assert!(matches!(
+            org_mode.update_todo(e).unwrap_err(),
+            OrgModeError::AmbiguousTarget(_)
+        ));
     }
 }

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -1,8 +1,69 @@
 use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use crate::OrgModeError;
 use crate::org_mode::capture::ParsedTimestamp;
 use crate::org_mode::{ClearField, OrgMode, UpdateEntry};
+
+static PLANNING_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(?:SCHEDULED|DEADLINE|CLOSED):").unwrap());
+static PLANNING_KV_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(SCHEDULED|DEADLINE|CLOSED):\s*(\[[^\]]*\]|<[^>]*>)").unwrap());
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct PlanningValues {
+    pub scheduled: Option<String>,
+    pub deadline: Option<String>,
+    pub closed: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PlanningBlock {
+    pub first_line: usize,
+    pub line_count: usize,
+    pub values: PlanningValues,
+}
+
+pub(crate) fn parse_planning_block(lines: &[String], headline_line: usize) -> PlanningBlock {
+    let mut values = PlanningValues::default();
+    let mut line_count = 0;
+    for line in lines.iter().skip(headline_line + 1) {
+        if !PLANNING_LINE_RE.is_match(line) {
+            break;
+        }
+        line_count += 1;
+        for cap in PLANNING_KV_RE.captures_iter(line) {
+            let raw = cap[2].to_string();
+            match &cap[1] {
+                "SCHEDULED" => values.scheduled = Some(raw),
+                "DEADLINE" => values.deadline = Some(raw),
+                "CLOSED" => values.closed = Some(raw),
+                _ => unreachable!("regex only matches the three keywords"),
+            }
+        }
+    }
+    PlanningBlock {
+        first_line: headline_line + 1,
+        line_count,
+        values,
+    }
+}
+
+pub(crate) fn render_planning_line(values: &PlanningValues) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(s) = &values.scheduled {
+        parts.push(format!("SCHEDULED: {s}"));
+    }
+    if let Some(d) = &values.deadline {
+        parts.push(format!("DEADLINE: {d}"));
+    }
+    if let Some(c) = &values.closed {
+        parts.push(format!("CLOSED: {c}"));
+    }
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -277,5 +338,73 @@ mod tests {
         e.todo_state = None;
         e.clear = vec![ClearField::Priority];
         assert!(org_mode.validate_update(&e).is_ok());
+    }
+
+    fn lines_of(content: &str) -> Vec<String> {
+        content.lines().map(String::from).collect()
+    }
+
+    #[test]
+    fn test_parse_planning_single_line() {
+        let lines = lines_of(
+            "* TODO Task\nSCHEDULED: <2026-05-15 Fri ++1w> DEADLINE: \
+            <2026-05-20 Wed>\nbody\n",
+        );
+        let block = parse_planning_block(&lines, 0);
+        assert_eq!(block.first_line, 1);
+        assert_eq!(block.line_count, 1);
+        assert_eq!(
+            block.values.scheduled.as_deref(),
+            Some("<2026-05-15 Fri ++1w>")
+        );
+        assert_eq!(block.values.deadline.as_deref(), Some("<2026-05-20 Wed>"));
+        assert_eq!(block.values.closed, None);
+    }
+
+    #[test]
+    fn test_parse_planning_multi_line_and_closed() {
+        let lines = lines_of(
+            "* DONE Task\nCLOSED: [2026-05-16 Sat 10:00]\nSCHEDULED: <2026-05-15 Fri>\nbody\n",
+        );
+        let block = parse_planning_block(&lines, 0);
+        assert_eq!(block.line_count, 2);
+        assert_eq!(
+            block.values.closed.as_deref(),
+            Some("[2026-05-16 Sat 10:00]")
+        );
+        assert_eq!(block.values.scheduled.as_deref(), Some("<2026-05-15 Fri>"));
+    }
+
+    #[test]
+    fn test_parse_planning_absent() {
+        let lines = lines_of("* TODO Task\n:PROPERTIES:\n:END:\n");
+        let block = parse_planning_block(&lines, 0);
+        assert_eq!(block.line_count, 0);
+        assert_eq!(block.values, PlanningValues::default());
+    }
+
+    #[test]
+    fn test_parse_planning_stops_at_body() {
+        let lines = lines_of(
+            "* TODO Task\nSCHEDULED: <2026-05-15 Fri>\nA note\nDEADLINE: \
+            <2026-05-20 Wed>\n",
+        );
+        let block = parse_planning_block(&lines, 0);
+        assert_eq!(block.line_count, 1);
+        assert_eq!(block.values.deadline, None);
+    }
+
+    #[test]
+    fn test_render_planning_line_order_and_none() {
+        let values = PlanningValues {
+            scheduled: Some("<2026-05-15 Fri>".to_string()),
+            deadline: None,
+            closed: Some("[2026-05-16 Sat]".to_string()),
+        };
+        assert_eq!(
+            render_planning_line(&values).as_deref(),
+            Some("SCHEDULED: <2026-05-15 Fri> CLOSED: [2026-05-16 Sat]")
+        );
+        assert_eq!(render_planning_line(&PlanningValues::default()), None);
     }
 }

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -1,62 +1,19 @@
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::LazyLock;
 
 use orgize::export::{Container, Event, from_fn, from_fn_with_ctx};
 use orgize::{Org, ParseConfig};
-use regex::Regex;
 
 use crate::OrgModeError;
 use crate::org_mode::capture::ParsedTimestamp;
 use crate::org_mode::{ClearField, OrgMode, UpdateEntry, UpdateResult};
-
-#[allow(dead_code)]
-static PLANNING_LINE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\s*(?:SCHEDULED|DEADLINE|CLOSED):").unwrap());
-#[allow(dead_code)]
-static PLANNING_KV_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(SCHEDULED|DEADLINE|CLOSED):\s*(\[[^\]]*\]|<[^>]*>)").unwrap());
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct PlanningValues {
     pub scheduled: Option<String>,
     pub deadline: Option<String>,
     pub closed: Option<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug)]
-pub(crate) struct PlanningBlock {
-    pub first_line: usize,
-    pub line_count: usize,
-    pub values: PlanningValues,
-}
-
-#[allow(dead_code)]
-pub(crate) fn parse_planning_block(lines: &[String], headline_line: usize) -> PlanningBlock {
-    let mut values = PlanningValues::default();
-    let mut line_count = 0;
-    for line in lines.iter().skip(headline_line + 1) {
-        if !PLANNING_LINE_RE.is_match(line) {
-            break;
-        }
-        line_count += 1;
-        for cap in PLANNING_KV_RE.captures_iter(line) {
-            let raw = cap[2].to_string();
-            match &cap[1] {
-                "SCHEDULED" => values.scheduled = Some(raw),
-                "DEADLINE" => values.deadline = Some(raw),
-                "CLOSED" => values.closed = Some(raw),
-                _ => unreachable!("regex only matches the three keywords"),
-            }
-        }
-    }
-    PlanningBlock {
-        first_line: headline_line + 1,
-        line_count,
-        values,
-    }
 }
 
 pub(crate) fn render_planning_line(values: &PlanningValues) -> Option<String> {
@@ -766,60 +723,6 @@ mod tests {
         e.todo_state = None;
         e.clear = vec![ClearField::Priority];
         assert!(org_mode.validate_update(&e).is_ok());
-    }
-
-    fn lines_of(content: &str) -> Vec<String> {
-        content.lines().map(String::from).collect()
-    }
-
-    #[test]
-    fn test_parse_planning_single_line() {
-        let lines = lines_of(
-            "* TODO Task\nSCHEDULED: <2026-05-15 Fri ++1w> DEADLINE: \
-            <2026-05-20 Wed>\nbody\n",
-        );
-        let block = parse_planning_block(&lines, 0);
-        assert_eq!(block.first_line, 1);
-        assert_eq!(block.line_count, 1);
-        assert_eq!(
-            block.values.scheduled.as_deref(),
-            Some("<2026-05-15 Fri ++1w>")
-        );
-        assert_eq!(block.values.deadline.as_deref(), Some("<2026-05-20 Wed>"));
-        assert_eq!(block.values.closed, None);
-    }
-
-    #[test]
-    fn test_parse_planning_multi_line_and_closed() {
-        let lines = lines_of(
-            "* DONE Task\nCLOSED: [2026-05-16 Sat 10:00]\nSCHEDULED: <2026-05-15 Fri>\nbody\n",
-        );
-        let block = parse_planning_block(&lines, 0);
-        assert_eq!(block.line_count, 2);
-        assert_eq!(
-            block.values.closed.as_deref(),
-            Some("[2026-05-16 Sat 10:00]")
-        );
-        assert_eq!(block.values.scheduled.as_deref(), Some("<2026-05-15 Fri>"));
-    }
-
-    #[test]
-    fn test_parse_planning_absent() {
-        let lines = lines_of("* TODO Task\n:PROPERTIES:\n:END:\n");
-        let block = parse_planning_block(&lines, 0);
-        assert_eq!(block.line_count, 0);
-        assert_eq!(block.values, PlanningValues::default());
-    }
-
-    #[test]
-    fn test_parse_planning_stops_at_body() {
-        let lines = lines_of(
-            "* TODO Task\nSCHEDULED: <2026-05-15 Fri>\nA note\nDEADLINE: \
-            <2026-05-20 Wed>\n",
-        );
-        let block = parse_planning_block(&lines, 0);
-        assert_eq!(block.line_count, 1);
-        assert_eq!(block.values.deadline, None);
     }
 
     #[test]

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -11,8 +11,10 @@ use crate::OrgModeError;
 use crate::org_mode::capture::ParsedTimestamp;
 use crate::org_mode::{ClearField, OrgMode, UpdateEntry, UpdateResult};
 
+#[allow(dead_code)]
 static PLANNING_LINE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(?:SCHEDULED|DEADLINE|CLOSED):").unwrap());
+#[allow(dead_code)]
 static PLANNING_KV_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(SCHEDULED|DEADLINE|CLOSED):\s*(\[[^\]]*\]|<[^>]*>)").unwrap());
 
@@ -23,6 +25,7 @@ pub(crate) struct PlanningValues {
     pub closed: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct PlanningBlock {
     pub first_line: usize,
@@ -30,6 +33,7 @@ pub(crate) struct PlanningBlock {
     pub values: PlanningValues,
 }
 
+#[allow(dead_code)]
 pub(crate) fn parse_planning_block(lines: &[String], headline_line: usize) -> PlanningBlock {
     let mut values = PlanningValues::default();
     let mut line_count = 0;
@@ -349,7 +353,6 @@ impl OrgMode {
         };
 
         let mut lines: Vec<String> = content.lines().map(String::from).collect();
-
         // Resulting field values: explicit set > clear > existing.
         let cleared = |f: ClearField| entry.clear.contains(&f);
 

--- a/org-core/src/org_mode/update.rs
+++ b/org-core/src/org_mode/update.rs
@@ -71,8 +71,6 @@ pub(crate) fn render_planning_line(values: &PlanningValues) -> Option<String> {
 
 #[derive(Debug)]
 pub(crate) struct ResolvedUpdate {
-    #[allow(dead_code)]
-    pub file_rel: Option<String>,
     pub scheduled: Option<ParsedTimestamp>,
     pub deadline: Option<ParsedTimestamp>,
     pub closed: Option<ParsedTimestamp>,
@@ -207,16 +205,11 @@ impl OrgMode {
             .map(|v| Self::parse_iso_timestamp("closed", v))
             .transpose()?;
 
-        let file_rel = match entry.file {
-            Some(ref f) => {
-                Self::validate_relative_file_path(f)?;
-                Some(f.clone())
-            }
-            None => None,
-        };
+        if let Some(ref f) = entry.file {
+            Self::validate_relative_file_path(f)?;
+        }
 
         Ok(ResolvedUpdate {
-            file_rel,
             scheduled,
             deadline,
             closed,
@@ -711,6 +704,18 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_rejects_empty_heading_path_segment() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let org_mode = make_org_mode(&temp_dir);
+        let mut e = entry_by_path();
+        e.heading_path = Some("Daily Tasks//Buy groceries".to_string());
+        assert!(matches!(
+            org_mode.validate_update(&e).unwrap_err(),
+            OrgModeError::InvalidHeadingPath(_)
+        ));
+    }
+
+    #[test]
     fn test_validate_accepts_clear_only_update() {
         let temp_dir = tempfile::tempdir().unwrap();
         let org_mode = make_org_mode(&temp_dir);
@@ -1133,7 +1138,7 @@ Body line must survive.
 
         let mut e = update_by_id("task-book-789");
         e.todo_state = Some("TODO".to_string());
-        org_mode.update_todo(e.clone()).unwrap();
+        org_mode.update_todo(e).unwrap();
         let content = fs::read_to_string(temp_dir.path().join("notes.org")).unwrap();
         assert!(content.contains("** TODO Read book"));
         assert!(
@@ -1151,7 +1156,6 @@ Body line must survive.
             !groceries.lines().nth(1).unwrap_or("").contains("CLOSED:"),
             "config off must not stamp CLOSED:\n{groceries}"
         );
-        let _ = e;
     }
 
     #[test]

--- a/org-mcp-server/src/core.rs
+++ b/org-mcp-server/src/core.rs
@@ -30,5 +30,6 @@ impl OrgModeRouter {
             + Self::tool_router_search()
             + Self::tool_router_agenda()
             + Self::tool_router_capture()
+            + Self::tool_router_update_todo()
     }
 }

--- a/org-mcp-server/src/tools/mod.rs
+++ b/org-mcp-server/src/tools/mod.rs
@@ -2,3 +2,4 @@ mod org_agenda;
 mod org_capture;
 mod org_file_list;
 mod org_search;
+mod org_update_todo;

--- a/org-mcp-server/src/tools/org_update_todo.rs
+++ b/org-mcp-server/src/tools/org_update_todo.rs
@@ -1,0 +1,131 @@
+use org_core::{ClearField, OrgModeError};
+use rmcp::{
+    ErrorData as McpError,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ContentBlock, ErrorCode},
+    schemars, tool, tool_router,
+};
+
+use crate::core::OrgModeRouter;
+
+#[derive(Debug, schemars::JsonSchema, serde::Deserialize)]
+pub struct UpdateTodoRequest {
+    #[schemars(
+        description = "Org ID property of the target heading. Wins when file/heading_path are also given."
+    )]
+    pub id: Option<String>,
+    #[schemars(
+        description = "Relative file path within org directory. Required together with heading_path."
+    )]
+    pub file: Option<String>,
+    #[schemars(
+        description = "Slash-separated heading path (e.g., 'Projects/Work'). Required together with file."
+    )]
+    pub heading_path: Option<String>,
+    #[schemars(
+        description = "New TODO state keyword. Must match a configured keyword in org_todo_keywords."
+    )]
+    pub todo_state: Option<String>,
+    #[schemars(description = "New priority level: A, B, or C")]
+    pub priority: Option<String>,
+    #[schemars(
+        description = "Replace the tag list wholesale. Each tag must match ^[A-Za-z0-9_@]+$."
+    )]
+    pub tags: Option<Vec<String>>,
+    #[schemars(
+        description = "New SCHEDULED active timestamp (ISO 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM', optional repeater +N|++N|.+N{h|d|w|m|y} and warning -N{h|d|w|m|y})."
+    )]
+    pub scheduled: Option<String>,
+    #[schemars(description = "New DEADLINE active timestamp; same grammar as scheduled.")]
+    pub deadline: Option<String>,
+    #[schemars(
+        description = "CLOSED inactive timestamp. Usually auto-managed: stamped on done transitions, removed on reactivation."
+    )]
+    pub closed: Option<String>,
+    #[schemars(
+        description = "Fields to remove: 'todo_state', 'priority', 'tags', 'scheduled', 'deadline', 'closed'."
+    )]
+    pub clear: Option<Vec<String>>,
+}
+
+#[tool_router(router = "tool_router_update_todo", vis = "pub(crate)")]
+impl OrgModeRouter {
+    #[tool(
+        name = "org-update-todo",
+        description = "Update the TODO state and planning metadata of an existing heading. Target by org ID property or by file + slash heading path. Set todo_state, priority, tags (replaced wholesale), SCHEDULED/DEADLINE/CLOSED timestamps, and/or remove fields via the clear list. CLOSED is auto-managed on done/active transitions unless org_auto_closed_timestamp is disabled.",
+        annotations(title = "org-update-todo tool")
+    )]
+    async fn tool_update_todo(
+        &self,
+        Parameters(UpdateTodoRequest {
+            id,
+            file,
+            heading_path,
+            todo_state,
+            priority,
+            tags,
+            scheduled,
+            deadline,
+            closed,
+            clear,
+        }): Parameters<UpdateTodoRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let clear: Vec<ClearField> = match clear {
+            Some(values) => values
+                .iter()
+                .map(|v| v.parse::<ClearField>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| McpError {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: format!("Invalid clear value: {e}").into(),
+                    data: None,
+                })?,
+            None => Vec::new(),
+        };
+
+        let entry = org_core::UpdateEntry {
+            id,
+            file,
+            heading_path,
+            todo_state,
+            priority,
+            tags,
+            scheduled,
+            deadline,
+            closed,
+            clear,
+        };
+
+        let org_mode = self.org_mode.lock().await;
+
+        match org_mode.update_todo(entry) {
+            Ok(result) => match ContentBlock::json(&result) {
+                Ok(serialized) => Ok(CallToolResult::success(vec![serialized])),
+                Err(e) => Err(McpError {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: format!("Failed to serialize update result: {e}").into(),
+                    data: None,
+                }),
+            },
+            Err(e) => {
+                let error_code = match &e {
+                    OrgModeError::InvalidTodoKeyword(_)
+                    | OrgModeError::InvalidPriority(_)
+                    | OrgModeError::InvalidHeadingPath(_)
+                    | OrgModeError::InvalidTag(_)
+                    | OrgModeError::InvalidDirectory(_)
+                    | OrgModeError::InvalidTimestamp { .. }
+                    | OrgModeError::HeadingNotFound(_)
+                    | OrgModeError::AmbiguousTarget(_)
+                    | OrgModeError::InvalidUpdate(_) => ErrorCode::INVALID_PARAMS,
+                    _ => ErrorCode::INTERNAL_ERROR,
+                };
+                Err(McpError {
+                    code: error_code,
+                    message: format!("Failed to update todo: {e}").into(),
+                    data: None,
+                })
+            }
+        }
+    }
+}

--- a/org-mcp-server/tests/integration_tests/tools_tests.rs
+++ b/org-mcp-server/tests/integration_tests/tools_tests.rs
@@ -1371,3 +1371,117 @@ async fn test_org_capture_datetree() -> Result<(), Box<dyn std::error::Error>> {
     service.cancel().await?;
     Ok(())
 }
+
+// --- org-update-todo tool tests ---
+
+/// Tests that the org-update-todo tool is listed among available tools.
+#[tokio::test]
+#[traced_test]
+async fn test_list_tools_includes_update_todo() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let tools = service.list_tools(Default::default()).await?;
+    let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(
+        tool_names.contains(&"org-update-todo"),
+        "org-update-todo should be listed"
+    );
+
+    service.cancel().await?;
+    Ok(())
+}
+
+/// Tests marking a TODO as DONE by ID, including the auto CLOSED stamp.
+#[tokio::test]
+#[traced_test]
+async fn test_org_update_todo_mark_done_by_id() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let mut args = Map::new();
+    args.insert("id".to_string(), Value::String("task-groceries-456".into()));
+    args.insert("todo_state".to_string(), Value::String("DONE".into()));
+
+    let result = service
+        .call_tool(CallToolRequestParams::new("org-update-todo").with_arguments(args))
+        .await?;
+
+    assert!(!result.content.is_empty());
+    if let Some(content) = result.content.first() {
+        if let Some(text) = content.as_text() {
+            let update_result: serde_json::Value =
+                serde_json::from_str(&text.text).expect("Should be valid JSON");
+            assert_eq!(update_result["file_path"], "notes.org");
+            assert!(
+                update_result["heading_line"]
+                    .as_str()
+                    .unwrap()
+                    .contains("DONE Buy groceries"),
+                "expected DONE headline, got {}",
+                update_result["heading_line"]
+            );
+        } else {
+            panic!("Expected text content in org-update-todo result");
+        }
+    }
+
+    let content = std::fs::read_to_string(temp_dir.path().join("notes.org"))?;
+    assert!(content.contains("DONE Buy groceries"));
+    assert!(content.contains("CLOSED: ["), "expected auto CLOSED stamp");
+
+    service.cancel().await?;
+    Ok(())
+}
+
+/// Tests clearing a field via the clear list using file + heading_path targeting.
+#[tokio::test]
+#[traced_test]
+async fn test_org_update_todo_clear_by_path() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let mut args = Map::new();
+    args.insert("file".to_string(), Value::String("notes.org".into()));
+    args.insert(
+        "heading_path".to_string(),
+        Value::String("Daily Tasks/Buy groceries".into()),
+    );
+    args.insert(
+        "clear".to_string(),
+        Value::Array(vec![Value::String("priority".into())]),
+    );
+
+    let result = service
+        .call_tool(CallToolRequestParams::new("org-update-todo").with_arguments(args))
+        .await?;
+
+    assert!(!result.content.is_empty());
+    service.cancel().await?;
+    Ok(())
+}
+
+/// Tests that an unknown target yields an error result, not a crash.
+#[tokio::test]
+#[traced_test]
+#[allow(clippy::single_match)]
+async fn test_org_update_todo_not_found() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = setup_test_org_files()?;
+    let service = create_mcp_service!(&temp_dir);
+
+    let mut args = Map::new();
+    args.insert("id".to_string(), Value::String("no-such-id".into()));
+    args.insert("todo_state".to_string(), Value::String("DONE".into()));
+
+    let result = service
+        .call_tool(CallToolRequestParams::new("org-update-todo").with_arguments(args))
+        .await;
+
+    match result {
+        Ok(r) => assert_eq!(r.is_error, Some(true), "expected tool error result"),
+        Err(_) => {} // protocol-level error is also acceptable
+    }
+
+    service.cancel().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds new tool to update the TODO state, `org-update-todo`

## Behavior

- **Targeting** — by org `:ID:` property or by `--file` + slash heading path (e.g. `Projects/Work/Refactor API`); ID wins when both are given. Missing targets return `HeadingNotFound`, duplicate matches `AmbiguousTarget`.
- **Set fields** — `todo_state`, `priority`, `tags` (replaced wholesale), and `SCHEDULED`/`DEADLINE`/`CLOSED` timestamps (same ISO grammar as capture, repeaters and warnings included).
- **Clear fields** — explicit `--clear` / `clear` list (`todo_state`, `priority`, `tags`, `scheduled`, `deadline`, `closed`), distinct from "don't touch" (omitted).
- **Auto-CLOSED** — transitioning to a done keyword stamps `CLOSED: [now]`; reactivating (or stripping the keyword) removes it. New config knob `org_auto_closed_timestamp` (default `true`, env `ORG_ORG__ORG_AUTO_CLOSED_TIMESTAMP`) disables auto-management.
- **Surgical edits** — only the headline line and the planning block beneath it are rewritten; everything else in the file stays byte-identical, including repeaters on untouched timestamps. Planning lines are (re)placed before any property drawer.

## Out of scope (future work)

Title/body editing, property drawer updates, CLOCK/LOGBOOK entries, batch updates.
