### PR TITLE
feat: add agent skills plugin for Claude Code, Codex, Cursor, and OpenCode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "org-mcp-server-dev",
+  "description": "Development marketplace for org-mcp-server skills",
+  "owner": {
+    "name": "Sebastián Zaffarano",
+    "email": "sebas@zaffarano.com.ar"
+  },
+  "plugins": [
+    {
+      "name": "org-mcp-server",
+      "description": "Org-mode skills for agenda, task management, and document search",
+      "version": "0.1.0",
+      "source": "./",
+      "author": {
+        "name": "Sebastián Zaffarano",
+        "email": "sebas@zaffarano.com.ar"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "org-mcp-server",
+  "description": "Org-mode skills for Claude Code: agenda, capture, task updates, and document search",
+  "version": "0.1.0",
+  "author": {
+    "name": "Sebastián Zaffarano",
+    "email": "sebas@zaffarano.com.ar"
+  },
+  "homepage": "https://github.com/szaffarano/org-mcp-server",
+  "repository": "https://github.com/szaffarano/org-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "org-mode",
+    "agenda",
+    "tasks",
+    "search",
+    "notes",
+    "knowledge-management"
+  ],
+  "skills": "./skills/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "org-mcp-server",
+  "version": "0.1.0",
+  "description": "Org-mode skills for Codex: agenda, task management, and document search.",
+  "author": {
+    "name": "Sebastián Zaffarano",
+    "email": "sebas@zaffarano.com.ar",
+    "url": "https://github.com/szaffarano"
+  },
+  "homepage": "https://github.com/szaffarano/org-mcp-server",
+  "repository": "https://github.com/szaffarano/org-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "org-mode",
+    "agenda",
+    "tasks",
+    "search",
+    "notes",
+    "knowledge-management"
+  ],
+  "skills": "./skills/",
+  "hooks": {}
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "org-mcp-server",
+  "displayName": "Org MCP Server",
+  "description": "Org-mode skills for Cursor: agenda, task management, and document search",
+  "version": "0.1.0",
+  "author": {
+    "name": "Sebastián Zaffarano",
+    "email": "sebas@zaffarano.com.ar"
+  },
+  "homepage": "https://github.com/szaffarano/org-mcp-server",
+  "repository": "https://github.com/szaffarano/org-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "org-mode",
+    "agenda",
+    "tasks",
+    "search",
+    "notes",
+    "knowledge-management"
+  ],
+  "skills": "./skills/",
+  "hooks": {}
+}

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,53 @@
+# Installing org-mcp-server skills for OpenCode
+
+## Prerequisites
+
+- [OpenCode.ai](https://opencode.ai) installed
+- The `org` MCP server configured in your OpenCode setup
+
+## Installation
+
+Add org-mcp-server to the `plugin` array in your `opencode.json`
+(global or project-level):
+
+```json
+{
+  "plugin": ["org-mcp-server@git+https://github.com/szaffarano/org-mcp-server.git"]
+}
+```
+
+Restart OpenCode. The plugin registers the `org-agenda` and `org-search` skills.
+
+## Skills
+
+| Skill | Triggers |
+|---|---|
+| `org-agenda` | "show my agenda", "tasks for today", "what's overdue", "my TODOs" |
+| `org-search` | "search my notes for…", "list my org files", "show outline of…" |
+
+## Usage
+
+Use OpenCode's native `skill` tool to list or load skills:
+
+```
+use skill tool to list skills
+use skill tool to load org-agenda
+```
+
+## Updating
+
+To pin a specific version:
+
+```json
+{
+  "plugin": ["org-mcp-server@git+https://github.com/szaffarano/org-mcp-server.git#v0.1.0"]
+}
+```
+
+## Troubleshooting
+
+### Skills not found
+
+1. Verify the plugin line is in your `opencode.json`
+2. Check logs: `opencode run --print-logs "hello" 2>&1 | grep -i org`
+3. Make sure the `org` MCP server is running and configured

--- a/.opencode/plugins/org-mcp-server.js
+++ b/.opencode/plugins/org-mcp-server.js
@@ -1,0 +1,25 @@
+/**
+ * org-mcp-server plugin for OpenCode.ai
+ *
+ * Registers the org-mode skills directory so OpenCode discovers
+ * org-agenda and org-search without manual symlinks or config edits.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const OrgMcpServerPlugin = async ({ client, directory }) => {
+  const skillsDir = path.resolve(__dirname, '../../skills');
+
+  return {
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(skillsDir)) {
+        config.skills.paths.push(skillsDir);
+      }
+    }
+  };
+};

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
+authors = ["Sebastián Zaffarano <sebas@zaffarano.com.ar>"]
 license = "MIT"
 repository = "https://github.com/szaffarano/org-mcp-server"
 documentation = "https://github.com/szaffarano/org-mcp-server"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ linking capabilities for your org-mode files through the MCP protocol.
 - `org-agenda://` — List all agenda items and tasks
 - `org-agenda://today` — Today's scheduled agenda items
 - `org-agenda://week` — This week's scheduled agenda items
+- `org-agenda://day/{YYYY-MM-DD}` — Agenda for a specific day
+- `org-agenda://week/{N}` — Agenda for week number N
+- `org-agenda://month/{N}` — Agenda for month number N
+- `org-agenda://query/from/{YYYY-MM-DD}/to/{YYYY-MM-DD}` — Custom date range
 
 ### MCP Tools
 
@@ -379,6 +383,59 @@ You can configure the MCP server through environment variables in your agent con
   }
 }
 ```
+
+## Agent Skills Plugin
+
+This repository ships skills for Claude Code, Codex, Cursor, and OpenCode that
+guide agents to use the MCP server effectively. Skills cover agenda queries,
+document search, note capture, and task updates.
+
+| Skill | Purpose |
+|---|---|
+| `org-agenda` | Query agenda items by date, state, priority, and tags |
+| `org-search` | Search and browse org files and headings |
+| `org-capture` | Create new headings, tasks, and journal entries |
+| `org-update-todo` | Update TODO state, priority, tags, and timestamps |
+
+### Claude Code
+
+Install the plugin by pointing Claude Code at this repository:
+
+```bash
+# Add to your Claude Code plugin config
+claude plugin install github:szaffarano/org-mcp-server
+```
+
+Or add to `.claude/settings.json` manually:
+
+```json
+{
+  "plugins": ["github:szaffarano/org-mcp-server"]
+}
+```
+
+### Codex
+
+Add to your Codex plugin configuration using `.codex-plugin/plugin.json` from
+this repository.
+
+### Cursor
+
+Add to your Cursor plugin configuration using `.cursor-plugin/plugin.json` from
+this repository.
+
+### OpenCode
+
+Add to the `plugin` array in your `opencode.json`:
+
+```json
+{
+  "plugin": ["org-mcp-server@git+https://github.com/szaffarano/org-mcp-server.git"]
+}
+```
+
+See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for full OpenCode setup
+instructions.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "org-mcp-server",
+  "version": "0.1.0",
+  "description": "Org-mode skills for coding agents: agenda, task management, and document search",
+  "type": "module",
+  "main": ".opencode/plugins/org-mcp-server.js",
+  "keywords": [
+    "org-mode",
+    "agenda",
+    "tasks",
+    "search",
+    "notes",
+    "knowledge-management",
+    "skills"
+  ],
+  "author": {
+    "name": "Sebastián Zaffarano",
+    "email": "sebas@zaffarano.com.ar"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/szaffarano/org-mcp-server.git"
+  },
+  "homepage": "https://github.com/szaffarano/org-mcp-server"
+}

--- a/skills/org-agenda/SKILL.md
+++ b/skills/org-agenda/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: org-agenda
+description: >
+  View and manage org-mode agenda, scheduled tasks, TODOs, and deadlines via the org MCP server.
+  Use when the user asks about their schedule, agenda, tasks, or deadlines.
+  Triggers: "show my agenda", "what's on my schedule", "tasks for today", "tomorrow's agenda",
+  "what do I have this week", "show next week", "last week's tasks", "my TODOs",
+  "show deadlines", "high priority tasks", "what's overdue", or any request about
+  scheduled items, TODO states, or calendar-like task views.
+---
+
+# Org Agenda
+
+View and manage org-mode agenda items using the `@org` MCP server.
+
+## Tool — `mcp__org__org-agenda`
+
+Query agenda items with filtering and two display modes.
+
+**Parameters:**
+- `mode`: `"view"` (calendar-like, organized by date) or `"list"` (flat task list, default)
+- `start_date` / `end_date`: ISO 8601 (`YYYY-MM-DD`). Compute from relative terms.
+- `todo_states`: e.g. `["TODO"]`, `["DONE"]`, `["TODO", "IN_PROGRESS"]`
+- `priority`: `"A"`, `"B"`, or `"C"`
+- `tags`: e.g. `["work", "urgent"]`
+- `limit`: Max items to return
+
+**When to use each mode:**
+- `"view"` — Date-range queries (today, tomorrow, this week, last month, etc.)
+- `"list"` — Broad task listings without a specific date range (all TODOs, all done items)
+
+**Common patterns:**
+
+| Request | Parameters |
+|---|---|
+| Today's agenda | `mode: "view"`, both dates = today |
+| Tomorrow | `mode: "view"`, both dates = tomorrow |
+| This week | `mode: "view"`, start = Monday, end = Sunday |
+| Next week | `mode: "view"`, start = next Monday, end = next Sunday |
+| Last week | `mode: "view"`, start = prev Monday, end = prev Sunday |
+| All open tasks | `mode: "list"`, `todo_states: ["TODO"]` |
+| Done items | `mode: "list"`, `todo_states: ["DONE"]` |
+| High priority | add `priority: "A"` to any query |
+| Tagged items | add `tags: ["tag"]` to any query |
+
+## Priority filter caveat
+
+`priority` filtering only works in `"list"` mode. It is silently ignored in `"view"` mode —
+use `"list"` mode and add a date-range filter manually when you need both.
+
+## Resources
+
+Use `ReadMcpResourceTool` with `server: "org"` for quick snapshots without filtering:
+
+| URI | Content |
+|---|---|
+| `org-agenda://` | All agenda items |
+| `org-agenda://today` | Today's scheduled items |
+| `org-agenda://week` | This week's items |
+| `org-agenda://day/{YYYY-MM-DD}` | Agenda for a specific day |
+| `org-agenda://week/{N}` | Agenda for week number N |
+| `org-agenda://month/{N}` | Agenda for month number N |
+| `org-agenda://query/from/{YYYY-MM-DD}/to/{YYYY-MM-DD}` | Custom date range |
+
+Prefer the tool over resources when filtering by priority, tags, states, or custom date ranges.
+
+## Presentation
+
+- For `"view"` mode results, group items by date with clear date headers.
+- For `"list"` mode results, group by state or priority.
+- Highlight overdue items and upcoming deadlines.

--- a/skills/org-capture/SKILL.md
+++ b/skills/org-capture/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: org-capture
+description: >
+  Create new org-mode headings and notes via the org MCP server. Use when the user wants
+  to add a new task, note, journal entry, or any new heading to their org files.
+  Triggers: "add a task", "create a note", "capture this", "log an entry",
+  "add to my notes", "create a TODO", "add a journal entry", "record this idea",
+  or any request to write new content into org files.
+---
+
+# Org Capture
+
+Append new headings and notes to org files using the `mcp__org__org-capture` tool.
+
+## Tool — `mcp__org__org-capture`
+
+**Required:**
+- `title`: Heading text. Non-empty, no newlines.
+
+**Targeting (where to insert):**
+- `file`: Relative path within the org directory. Defaults to the configured notes file.
+- `target_heading`: Slash-separated path to insert under (e.g. `"Projects/Work"`).
+  Missing intermediate headings are created automatically.
+
+**Heading metadata:**
+- `level`: Heading depth (1–19). Defaults to `parent_level + 1` when `target_heading` is
+  set, else 1.
+- `todo_state`: Keyword matching `org_todo_keywords` config (e.g. `"TODO"`, `"DONE"`).
+- `priority`: `"A"`, `"B"`, or `"C"`.
+- `tags`: List of tag strings. Each must match `^[A-Za-z0-9_@]+$`.
+- `body`: Text placed beneath the heading.
+- `properties`: List of `{key, value}` pairs written into a property drawer.
+
+**Timestamps** (ISO `YYYY-MM-DD` or `YYYY-MM-DD HH:MM`, optional repeater/warning):
+- `scheduled`: SCHEDULED active timestamp.
+- `deadline`: DEADLINE active timestamp.
+- `closed`: CLOSED inactive timestamp.
+- Repeater syntax: `+N`, `++N`, or `.+N` followed by `h|d|w|m|y`.
+- Warning syntax: `-N` followed by `h|d|w|m|y`.
+
+**Datetree** (Year/Month/Day hierarchy):
+- `datetree: true`: Expand `target_heading` with a Year → Month → Day tree before
+  resolving, placing the entry under today's leaf.
+- `datetree_date`: Override the target day (`YYYY-MM-DD`). Only valid when `datetree` is
+  true.
+
+## Common patterns
+
+| Goal | Key parameters |
+|---|---|
+| Quick TODO | `title`, `todo_state: "TODO"` |
+| Scheduled task | `title`, `todo_state`, `scheduled` |
+| Journal entry today | `datetree: true`, `title`, `body` |
+| Journal entry specific day | `datetree: true`, `datetree_date: "YYYY-MM-DD"`, `title` |
+| Note under a heading | `target_heading: "Area/Subarea"`, `title`, `body` |
+| Note in specific file | `file: "relative/path.org"`, `title` |
+| Tagged note | `title`, `tags: ["tag1", "tag2"]` |
+| Note with properties | `title`, `properties: [{"key": "SOURCE", "value": "..."}]` |
+
+## After capture
+
+The tool returns the file path and the position of the newly created heading. Use
+`org-heading://{file}#{title}` to verify the result if needed.

--- a/skills/org-search/SKILL.md
+++ b/skills/org-search/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: org-search
+description: >
+  Search and browse org-mode documents via the org MCP server. Use when the user wants to
+  find content across org files, list their org documents, read file contents, or navigate
+  headings and outlines.
+  Triggers: "search my notes for...", "find org pages about...", "list my org files",
+  "show outline of...", "read the section about...", "find documents tagged with...",
+  "what files do I have about...", or any request to search, browse, read, or navigate
+  org-mode documents and their content.
+---
+
+# Org Search
+
+Search and browse org-mode documents using the `@org` MCP server.
+
+## Tools
+
+### Search — `mcp__org__org-search`
+
+Fuzzy text search across all org files.
+
+**Parameters:**
+- `query` (required): Search string
+- `tags`: Filter results by tags
+- `limit`: Max results
+- `snippet_max_size`: Snippet length in chars (default: 100). Use 300+ for more context.
+
+### File List — `mcp__org__org-file-list`
+
+List org files in the configured directory.
+
+**Parameters:**
+- `tags`: Filter by tags
+- `limit`: Max files
+
+## Resources
+
+Use `ReadMcpResourceTool` with `server: "org"` to access file content:
+
+| URI pattern | Use case |
+|---|---|
+| `org://` | List all org files |
+| `org://{file}` | Read full file content |
+| `org-outline://{file}` | Get heading structure (table of contents) |
+| `org-heading://{file}#{heading}` | Read a specific heading's content |
+| `org-id://{uuid}` | Access a node by its unique ID |
+
+## Workflow
+
+1. **Search for content**: Use `mcp__org__org-search` with the user's query. If results are
+   too broad, suggest narrowing with tags or more specific terms.
+2. **Browse files**: Use `mcp__org__org-file-list` to list available files, optionally
+   filtered by tags.
+3. **Explore structure**: Read `org-outline://{file}` to see a file's heading hierarchy
+   before diving in.
+4. **Read content**: Use `org://{file}` for full content or `org-heading://{file}#{heading}`
+   to read a specific section.
+5. **Present results**: Show file name, matched heading, and relevant snippet. Link to
+   deeper content when available.

--- a/skills/org-update-todo/SKILL.md
+++ b/skills/org-update-todo/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: org-update-todo
+description: >
+  Update the TODO state and metadata of an existing org-mode heading via the org MCP server.
+  Use when the user wants to change a task's state, priority, tags, or timestamps.
+  Triggers: "mark as done", "complete this task", "reschedule", "change priority",
+  "update the deadline", "close this TODO", "set a deadline", "retag this", "move to IN_PROGRESS",
+  or any request to modify an existing task or heading's metadata.
+---
+
+# Org Update Todo
+
+Update TODO state and planning metadata of existing headings using `mcp__org__org-update-todo`.
+
+## Tool — `mcp__org__org-update-todo`
+
+### Targeting (one of these is required)
+
+**By ID (preferred):** supply `id` — the `:ID:` property value of the heading.
+Wins over file/heading_path when both are given.
+
+**By location:** supply both `file` (relative path within org directory) and
+`heading_path` (slash-separated path, e.g. `"Projects/Work/Task name"`).
+
+### Fields to update (all optional — omit what you don't want to change)
+
+- `todo_state`: New keyword matching `org_todo_keywords` (e.g. `"TODO"`, `"DONE"`).
+  `CLOSED` is auto-stamped on done transitions and auto-removed on reactivation unless
+  `org_auto_closed_timestamp` is disabled in config.
+- `priority`: `"A"`, `"B"`, or `"C"`.
+- `tags`: Replaces the tag list wholesale. Each must match `^[A-Za-z0-9_@]+$`.
+  Pass an empty list `[]` to remove all tags.
+
+**Timestamps** (ISO `YYYY-MM-DD` or `YYYY-MM-DD HH:MM`, optional repeater/warning):
+- `scheduled`: New SCHEDULED active timestamp.
+- `deadline`: New DEADLINE active timestamp.
+- `closed`: New CLOSED inactive timestamp (usually auto-managed; set manually only when
+  overriding auto-close behavior).
+- Repeater syntax: `+N`, `++N`, or `.+N` followed by `h|d|w|m|y`.
+- Warning syntax: `-N` followed by `h|d|w|m|y`.
+
+**Clearing fields:**
+- `clear`: List of field names to remove entirely.
+  Valid values: `"todo_state"`, `"priority"`, `"tags"`, `"scheduled"`, `"deadline"`,
+  `"closed"`.
+
+## Common patterns
+
+| Goal | Key parameters |
+|---|---|
+| Mark done | `id` or `file`+`heading_path`, `todo_state: "DONE"` |
+| Start working | `todo_state: "IN_PROGRESS"` |
+| Reopen a task | `todo_state: "TODO"`, `clear: ["closed"]` |
+| Raise priority | `priority: "A"` |
+| Reschedule | `scheduled: "YYYY-MM-DD"` |
+| Set deadline | `deadline: "YYYY-MM-DD"` |
+| Remove deadline | `clear: ["deadline"]` |
+| Retag | `tags: ["new_tag1", "new_tag2"]` |
+| Remove all tags | `tags: []` |
+
+## Workflow
+
+1. **Find the target**: Use `mcp__org__org-search` or `mcp__org__org-agenda` to locate the
+   heading. Prefer using its `:ID:` property if available.
+2. **Apply the update**: Call `mcp__org__org-update-todo` with the target and desired fields.
+3. **Confirm**: The tool returns the updated heading state. Verify the result matches intent.


### PR DESCRIPTION
## Summary

- Adds four agent skills (`org-agenda`, `org-search`, `org-capture`, `org-update-todo`) under `skills/` so coding agents know how to use the MCP server tooling without per-session instruction
- Adds plugin manifests for Claude Code (`.claude-plugin/`), Codex (`.codex-plugin/`), Cursor (`.cursor-plugin/`), and OpenCode (`.opencode/`) following the superpowers plugin convention
- Adds `package.json` as the npm entry point for OpenCode's git-backed plugin installer
- Updates `README.md` with missing `org-agenda` resource templates and a new **Agent Skills Plugin** section with per-harness install instructions